### PR TITLE
Add Christmas tree script

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ dev = [
 ]
 
 [project.scripts]
+christmas = "microswea.run.christmas:main"
 micro = "microswea.__main__:main"
 micro2 = "microswea.run.local2:cli"
 micro-swe-agent = "microswea.__main__:main"

--- a/src/microswea/run/README.md
+++ b/src/microswea/run/README.md
@@ -1,5 +1,7 @@
 # Entry points / run scripts
 
+* `christmas.py` - Prints a beautiful Christmas tree and exits.
+
 ## Work locally (i.e., without a sandbox)
 
 * `hello_world.py` - Extremely simple example of how to use the `default.py` agent.

--- a/src/microswea/run/christmas.py
+++ b/src/microswea/run/christmas.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""
+Christmas tree script that prints a Christmas tree and exits.
+"""
+
+def print_christmas_tree():
+    """Print a beautiful Christmas tree."""
+    tree = """
+        🌟
+       /|\\
+      /*|O\\
+     /*/|\\*\\
+    /X/O|*\\X\\
+   /*/X/|\\X\\*\\
+  /O/*/X|*\\O\\X\\
+ /*/O/X/|\\X\\O\\*\\
+/X/O/*/X|O\\X\\*\\O\\
+        |X|
+        |X|
+"""
+    print(tree)
+    print("🎄 Merry Christmas! 🎄")
+
+def main():
+    """Main entry point for the Christmas tree script."""
+    print_christmas_tree()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR adds a Christmas tree script as requested in issue #74.

Changes:
- Created `src/microswea/run/christmas.py` that prints a beautiful Christmas tree and exits
- Added CLI entry point "christmas" in pyproject.toml
- Updated run/README.md to document the new script

The script can be run directly with `python src/microswea/run/christmas.py` or installed as a CLI command `christmas` after package installation.

Fixes #74