### PR TITLE
Add SWE-smith

### DIFF
--- a/src/microsweagent/run/extra/swebench.py
+++ b/src/microsweagent/run/extra/swebench.py
@@ -28,6 +28,7 @@ DATASET_MAPPING = {
     "lite": "princeton-nlp/SWE-Bench_Lite",
     "multimodal": "princeton-nlp/SWE-Bench_Multimodal",
     "multilingual": "swe-bench/SWE-Bench_Multilingual",
+    "smith": "SWE-bench/SWE-smith",
     "_test": "klieret/swe-bench-dummy-test-dataset",
 }
 
@@ -210,10 +211,7 @@ def main(
     ),
 ) -> None:
     """Run micro-SWE-agent on SWEBench instances"""
-    try:
-        dataset_path = DATASET_MAPPING[subset]
-    except KeyError:
-        dataset_path = subset
+    dataset_path = DATASET_MAPPING.get(subset, subset)
     print(f"Loading dataset {dataset_path}, split {split}...")
     instances = list(load_dataset(dataset_path, split=split))
 


### PR DESCRIPTION
Adding SWE-smith is super easy! Literally 0 changes required to the `extra/swebench.py` file 😝

```
$ python src/microsweagent/run/extra/swebench.py --subset smith --split train --slice '0:3'
👋 This is micro-swe-agent version 1.0.0.dev3.
Your config is stored in '/home/john-b-yang/.config/micro-swe-agent/.env'
Loading dataset SWE-bench/SWE-smith, split train...
Instance slice: 50137 -> 3 instances
Skipping 1 existing instances
Running on 2 instances...
Results will be saved to .
Running instance 1/2: john-kurkowski__tldextract.3d1bf184.combine_file__28bpyc3y
Starting container with command: docker run -d --name microsweagent-3624da85 -w /testbed jyangballin/swesmith.x86_64.john-kurkowski_1776_tldextract.3d1bf184 sleep infinity
Started container microsweagent-3624da85 with ID 450501cf052125bc4c770df273f5830a546f0e04897fde508d2fea7b865efb4e
Stopping container 450501cf052125bc4c770df273f5830a546f0e04897fde508d2fea7b865efb4e (might take a second)
Instance john-kurkowski__tldextract.3d1bf184.combine_file__28bpyc3y completed - completed 1/2, $0.2503
Running instance 2/2: john-kurkowski__tldextract.3d1bf184.combine_file__2fa4wcjb
Starting container with command: docker run -d --name microsweagent-5a40f2b7 -w /testbed jyangballin/swesmith.x86_64.john-kurkowski_1776_tldextract.3d1bf184 sleep infinity
Started container microsweagent-5a40f2b7 with ID 3b94a526869032be3c865de34068acad6dd9d5eb344c1d1fed9ebea01681bf84
Stopping container 3b94a526869032be3c865de34068acad6dd9d5eb344c1d1fed9ebea01681bf84 (might take a second)
Instance john-kurkowski__tldextract.3d1bf184.combine_file__2fa4wcjb completed - completed 2/2, $0.2590
```

Also made a tiny simplification to the `DATASET_MAPPING.get` logic.