### PR TITLE
add responsive task prompt for micro command

### DIFF
--- a/src/microsweagent/run/micro.py
+++ b/src/microsweagent/run/micro.py
@@ -89,13 +89,11 @@ def main(
     config = yaml.safe_load(get_config_path(config_spec).read_text())
 
     if not task:
-        console.print(
-            "[bold yellow]What do you want to do?\n"
-            "[bold green]Up[/bold green]/[bold green]Down[/bold green] to bring up previous tasks or [bold green]Ctrl+R[/bold green] to search history\n"
-        )
+        console.print("[bold yellow]What do you want to do?")
         task = prompt_session.prompt("", multiline=True, bottom_toolbar=[
-            ("", "Confirm with "),
-            ("bg:red bold", "Esc+Enter")
+            ("", "Submit task: "), ("fg:ansiyellow bg:black bold", "Esc+Enter"),
+            ("", " | Navigate history: "), ("fg:ansiyellow bg:black bold", "Arrow Up/Down"),
+            ("", " | Search history: "), ("fg:ansiyellow bg:black bold", "Ctrl+R"),
         ])
         console.print("[bold green]Got that, thanks![/bold green]")
 


### PR DESCRIPTION
This updates the main `micro` task prompt with a responsive bottom toolbar.
When Escape is pressed and the prompt is ready to be submitted, we update the bottom toolbar from "Confirm with Esc, then Enter" to "Press Enter to submit". Behavior before had "Confirm with Esc, then Enter" before and after pressing Escape, leaving some ambiguity to how to submit.