### PR TITLE
(Minor) Show SWE-agent paper citation

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,10 +208,7 @@ Read more in our [documentation](https://mini-swe-agent.com/latest/):
 
 ## Bottom line
 
-If you found this work helpful, please consider citing
-
-<details>
-<summary> SWE-agent citation</summary>
+If you found this work helpful, please consider citing the [SWE-agent paper](https://arxiv.org/abs/2405.15793) in your work:
 
 ```bibtex
 @inproceedings{yang2024sweagent,
@@ -222,7 +219,6 @@ If you found this work helpful, please consider citing
   url={https://arxiv.org/abs/2405.15793}
 }
 ```
-</details>
 
 More agentic AI:
 


### PR DESCRIPTION
With the drop down, I think the citation might be a bit easy to miss. Proposing we remove the `<details>` stuff so it's apparent :)