### PR TITLE
Fix #144: Enable different kinds of parsers for actions

### DIFF
--- a/src/minisweagent/agents/default.py
+++ b/src/minisweagent/agents/default.py
@@ -11,11 +11,6 @@ from jinja2 import Template
 
 from minisweagent import Environment, Model
 
-ActionParserMap = {
-    "backticks": r"```bash\n(.*?)\n```",
-    "xml": r"<command>(.*?)</command>",
-}
-
 
 @dataclass
 class AgentConfig:
@@ -32,7 +27,7 @@ class AgentConfig:
     )
     format_error_template: str = "Please always provide EXACTLY ONE action in triple backticks."
     action_observation_template: str = "Observation: {{output}}"
-    action_parser: str = "backticks"  # Options: "backticks", "xml"
+    action_parser: str = "```bash\n(.*?)\n```"
     step_limit: int = 0
     cost_limit: float = 3.0
 
@@ -110,7 +105,7 @@ class DefaultAgent:
 
     def parse_action(self, response: dict) -> dict:
         """Parse the action from the message. Returns the action."""
-        actions = re.findall(ActionParserMap[self.config.action_parser], response["content"], re.DOTALL)
+        actions = re.findall(self.config.action_parser, response["content"], re.DOTALL)
         if len(actions) == 1:
             return {"action": actions[0].strip(), **response}
         raise FormatError(self.render_template(self.config.format_error_template, actions=actions))

--- a/src/minisweagent/agents/default.py
+++ b/src/minisweagent/agents/default.py
@@ -11,6 +11,11 @@ from jinja2 import Template
 
 from minisweagent import Environment, Model
 
+ActionParserMap = {
+    "backticks": r"```bash\n(.*?)\n```",
+    "xml": r"<command>(.*?)</command>",
+}
+
 
 @dataclass
 class AgentConfig:
@@ -27,6 +32,7 @@ class AgentConfig:
     )
     format_error_template: str = "Please always provide EXACTLY ONE action in triple backticks."
     action_observation_template: str = "Observation: {{output}}"
+    action_parser: str = "backticks"  # Options: "backticks", "xml"
     step_limit: int = 0
     cost_limit: float = 3.0
 
@@ -104,7 +110,7 @@ class DefaultAgent:
 
     def parse_action(self, response: dict) -> dict:
         """Parse the action from the message. Returns the action."""
-        actions = re.findall(r"```bash\n(.*?)\n```", response["content"], re.DOTALL)
+        actions = re.findall(ActionParserMap[self.config.action_parser], response["content"], re.DOTALL)
         if len(actions) == 1:
             return {"action": actions[0].strip(), **response}
         raise FormatError(self.render_template(self.config.format_error_template, actions=actions))

--- a/src/minisweagent/config/default.yaml
+++ b/src/minisweagent/config/default.yaml
@@ -128,7 +128,7 @@ agent:
     <action>
     ```
     </response_example>
-  action_parser: backticks
+  action_parser: "```bash\n(.*?)\n```"
   step_limit: 0.
   cost_limit: 0.
 environment:

--- a/src/minisweagent/config/default.yaml
+++ b/src/minisweagent/config/default.yaml
@@ -128,6 +128,7 @@ agent:
     <action>
     ```
     </response_example>
+  action_parser: backticks
   step_limit: 0.
   cost_limit: 0.
 environment:

--- a/src/minisweagent/config/extra/default_xml.yaml
+++ b/src/minisweagent/config/extra/default_xml.yaml
@@ -9,9 +9,9 @@ agent:
     <format_example>
     Your reasoning and analysis here. Explain why you want to perform the action.
 
-    ```bash
+    <command>
     your_command_here
-    ```
+    </command>
     </format_example>
 
     Failure to follow these rules will cause your response to be rejected.
@@ -38,10 +38,6 @@ agent:
     4. To finish, issue the following command: `echo MINI_SWE_AGENT_FINAL_OUTPUT`.
        Do not combine it with any other command.
 
-    <system_information>
-    {{system}} {{release}} {{version}} {{machine}} {{processor}}
-    </system_information>
-
     ## Formatting your response
 
     Here is an example of a correct response:
@@ -49,32 +45,26 @@ agent:
     <example_response>
     THOUGHT: I need to understand the structure of the repository first. Let me check what files are in the current directory to get a better understanding of the codebase.
 
-    ```bash
+    <command>
     ls -la
-    ```
+    </command>
     </example_response>
 
     ## Useful command examples
 
     ### Create a new file:
 
-    ```bash
-    cat <<'EOF' > newfile.py
+    <command>
+    cat <<'EOF' >> newfile.py
     import numpy as np
     hello = "world"
     print(hello)
     EOF
-    ```
+    </command>
 
     ### Edit files with sed:
 
-    {%- if system == "Darwin" -%}
-    <important>
-    You are on MacOS. For all the below examples, you need to use `sed -i ''` instead of `sed -i`.
-    </important>
-    {%- endif -%}
-
-    ```bash
+    <command>
     # Replace all occurrences
     sed -i 's/old_string/new_string/g' filename.py
 
@@ -86,20 +76,20 @@ agent:
 
     # Replace all occurrences in lines 1-10
     sed -i '1,10s/old_string/new_string/g' filename.py
-    ```
+    </command>
 
     ### View file content:
 
-    ```bash
+    <command>
     # View specific lines with numbers
     nl -ba filename.py | sed -n '10,20p'
-    ```
+    </command>
 
     ### Any other command you want to run
 
-    ```bash
+    <command>
     anything
-    ```
+    </command>
   action_observation_template: |
     <returncode>{{output.returncode}}</returncode>
     {% if output.output | length < 10000 -%}
@@ -134,14 +124,13 @@ agent:
     <response_example>
     Here are some thoughts about why you want to perform the action.
 
-    ```bash
+    <command>
     <action>
-    ```
+    </command>
     </response_example>
-  action_parser: "```bash\n(.*?)\n```"
+  action_parser: "<command>(.*?)</command>"
   step_limit: 0.
-  cost_limit: 3.
-  mode: confirm
+  cost_limit: 0.
 environment:
   env:
     PAGER: cat

--- a/src/minisweagent/config/extra/swebench.yaml
+++ b/src/minisweagent/config/extra/swebench.yaml
@@ -209,7 +209,7 @@ agent:
 
     If you have completed your assignment, please consult the first message about how to
     submit your solution (you will not be able to continue working on this task after that).
-  action_parser: backticks
+  action_parser: "```bash\n(.*?)\n```"
   step_limit: 250
   cost_limit: 3.
 

--- a/src/minisweagent/config/extra/swebench.yaml
+++ b/src/minisweagent/config/extra/swebench.yaml
@@ -209,6 +209,7 @@ agent:
 
     If you have completed your assignment, please consult the first message about how to
     submit your solution (you will not be able to continue working on this task after that).
+  action_parser: backticks
   step_limit: 250
   cost_limit: 3.
 

--- a/src/minisweagent/config/github_issue.yaml
+++ b/src/minisweagent/config/github_issue.yaml
@@ -128,7 +128,7 @@ agent:
     <action>
     ```
     </response_example>
-  action_parser: backticks
+  action_parser: "```bash\n(.*?)\n```"
   step_limit: 0.
   cost_limit: 0.
 

--- a/src/minisweagent/config/github_issue.yaml
+++ b/src/minisweagent/config/github_issue.yaml
@@ -128,6 +128,7 @@ agent:
     <action>
     ```
     </response_example>
+  action_parser: backticks
   step_limit: 0.
   cost_limit: 0.
 

--- a/src/minisweagent/config/mini.yaml
+++ b/src/minisweagent/config/mini.yaml
@@ -138,6 +138,7 @@ agent:
     <action>
     ```
     </response_example>
+  action_parser: backticks
   step_limit: 0.
   cost_limit: 3.
   mode: confirm


### PR DESCRIPTION
Enables specifying different kinds of action parsers via the config.
* Adds an `ActionParserMap` + `action_parser` property to the `AgentConfig` class
* Add `action_parser` key to existing `src/minisweagent/*.yaml` configs.