### PR TITLE
Enh/custom litellm registry

### DIFF
--- a/docs/advanced/configuration.md
+++ b/docs/advanced/configuration.md
@@ -79,6 +79,38 @@ MSWEA_GLOBAL_CALL_LIMIT="100"
 MSWEA_GLOBAL_COST_LIMIT="10.00"
 ```
 
+#### Updating the LiteLLM model registry
+
+LiteLLM get its cost and model metadata from [this file](https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json). You can override or add data from this file if it's outdated or missing your desired model by including a custom registry file in the model config:
+
+```yaml
+model:
+  litellm_model_registry: "path/to/model_registry.json"
+  ...
+...
+```
+
+The model registry JSON file should follow LiteLLM's format:
+
+```json
+{
+  "my-custom-model": {
+    "max_tokens": 4096,
+    "input_cost_per_token": 0.0001,
+    "output_cost_per_token": 0.0002,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "my-local-model": {
+    "max_tokens": 8192,
+    "input_cost_per_token": 0.0,
+    "output_cost_per_token": 0.0,
+    "litellm_provider": "ollama",
+    "mode": "chat"
+  }
+}
+```
+
 ### Default config files
 
 ```bash

--- a/src/minisweagent/models/litellm_model.py
+++ b/src/minisweagent/models/litellm_model.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from dataclasses import dataclass, field
 from typing import Any
@@ -20,6 +21,7 @@ logger = logging.getLogger("litellm_model")
 class LitellmModelConfig:
     model_name: str
     model_kwargs: dict[str, Any] = field(default_factory=dict)
+    litellm_model_registry: str | None = None
 
 
 class LitellmModel:
@@ -27,6 +29,10 @@ class LitellmModel:
         self.config = LitellmModelConfig(**kwargs)
         self.cost = 0.0
         self.n_calls = 0
+        if self.config.litellm_model_registry is not None:
+            with open(self.config.litellm_model_registry) as f:
+                model_costs = json.load(f)
+                litellm.register_model(model_costs)
 
     @retry(
         stop=stop_after_attempt(10),

--- a/src/minisweagent/models/litellm_model.py
+++ b/src/minisweagent/models/litellm_model.py
@@ -1,6 +1,7 @@
 import json
 import logging
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any
 
 import litellm
@@ -21,7 +22,7 @@ logger = logging.getLogger("litellm_model")
 class LitellmModelConfig:
     model_name: str
     model_kwargs: dict[str, Any] = field(default_factory=dict)
-    litellm_model_registry: str | None = None
+    litellm_model_registry: Path | None = None
 
 
 class LitellmModel:
@@ -30,9 +31,7 @@ class LitellmModel:
         self.cost = 0.0
         self.n_calls = 0
         if self.config.litellm_model_registry is not None:
-            with open(self.config.litellm_model_registry) as f:
-                model_registry = json.load(f)
-                litellm.register_model(model_registry)
+            litellm.utils.register_model(json.loads(self.config.litellm_model_registry.read_text()))
 
     @retry(
         stop=stop_after_attempt(10),

--- a/src/minisweagent/models/litellm_model.py
+++ b/src/minisweagent/models/litellm_model.py
@@ -31,8 +31,8 @@ class LitellmModel:
         self.n_calls = 0
         if self.config.litellm_model_registry is not None:
             with open(self.config.litellm_model_registry) as f:
-                model_costs = json.load(f)
-                litellm.register_model(model_costs)
+                model_registry = json.load(f)
+                litellm.register_model(model_registry)
 
     @retry(
         stop=stop_after_attempt(10),

--- a/tests/models/test_litellm_model.py
+++ b/tests/models/test_litellm_model.py
@@ -1,4 +1,7 @@
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, patch, mock_open
+import json
+import tempfile
+from pathlib import Path
 
 import litellm
 import pytest
@@ -26,3 +29,50 @@ def test_authentication_error_enhanced_message():
 
         # Check that the error message was enhanced
         assert "You can permanently set your API key with `mini-extra config set KEY VALUE`." in str(exc_info.value)
+
+
+def test_model_registry_loading():
+    """Test that custom model registry is loaded and registered when provided."""
+    model_costs = {
+        "my-custom-model": {
+            "max_tokens": 4096,
+            "input_cost_per_token": 0.0001,
+            "output_cost_per_token": 0.0002,
+            "litellm_provider": "openai",
+            "mode": "chat"
+        }
+    }
+    
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+        json.dump(model_costs, f)
+        registry_path = f.name
+    
+    try:
+        with patch("litellm.register_model") as mock_register:
+            model = LitellmModel(
+                model_name="my-custom-model",
+                litellm_model_registry=registry_path
+            )
+            
+            # Verify register_model was called with the correct data
+            mock_register.assert_called_once_with(model_costs)
+    finally:
+        Path(registry_path).unlink()
+
+
+def test_model_registry_none():
+    """Test that no registry loading occurs when litellm_model_registry is None."""
+    with patch("litellm.register_model") as mock_register:
+        model = LitellmModel(model_name="gpt-4", litellm_model_registry=None)
+        
+        # Verify register_model was not called
+        mock_register.assert_not_called()
+
+
+def test_model_registry_not_provided():
+    """Test that no registry loading occurs when litellm_model_registry is not provided."""
+    with patch("litellm.register_model") as mock_register:
+        model = LitellmModel(model_name="gpt-4o")
+        
+        # Verify register_model was not called
+        mock_register.assert_not_called()

--- a/tests/models/test_litellm_model.py
+++ b/tests/models/test_litellm_model.py
@@ -42,15 +42,15 @@ def test_model_registry_loading():
             "mode": "chat",
         }
     }
-    
+
     with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
         json.dump(model_costs, f)
         registry_path = f.name
-    
+
     try:
         with patch("litellm.register_model") as mock_register:
             _model = LitellmModel(model_name="my-custom-model", litellm_model_registry=registry_path)
-            
+
             # Verify register_model was called with the correct data
             mock_register.assert_called_once_with(model_costs)
     finally:
@@ -61,7 +61,7 @@ def test_model_registry_none():
     """Test that no registry loading occurs when litellm_model_registry is None."""
     with patch("litellm.register_model") as mock_register:
         _model = LitellmModel(model_name="gpt-4", litellm_model_registry=None)
-        
+
         # Verify register_model was not called
         mock_register.assert_not_called()
 
@@ -70,6 +70,6 @@ def test_model_registry_not_provided():
     """Test that no registry loading occurs when litellm_model_registry is not provided."""
     with patch("litellm.register_model") as mock_register:
         _model = LitellmModel(model_name="gpt-4o")
-        
+
         # Verify register_model was not called
         mock_register.assert_not_called()

--- a/tests/models/test_litellm_model.py
+++ b/tests/models/test_litellm_model.py
@@ -1,7 +1,7 @@
-from unittest.mock import Mock, patch, mock_open
 import json
 import tempfile
 from pathlib import Path
+from unittest.mock import Mock, patch
 
 import litellm
 import pytest
@@ -39,21 +39,18 @@ def test_model_registry_loading():
             "input_cost_per_token": 0.0001,
             "output_cost_per_token": 0.0002,
             "litellm_provider": "openai",
-            "mode": "chat"
+            "mode": "chat",
         }
     }
-    
-    with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
         json.dump(model_costs, f)
         registry_path = f.name
-    
+
     try:
         with patch("litellm.register_model") as mock_register:
-            model = LitellmModel(
-                model_name="my-custom-model",
-                litellm_model_registry=registry_path
-            )
-            
+            model = LitellmModel(model_name="my-custom-model", litellm_model_registry=registry_path)
+
             # Verify register_model was called with the correct data
             mock_register.assert_called_once_with(model_costs)
     finally:
@@ -64,7 +61,7 @@ def test_model_registry_none():
     """Test that no registry loading occurs when litellm_model_registry is None."""
     with patch("litellm.register_model") as mock_register:
         model = LitellmModel(model_name="gpt-4", litellm_model_registry=None)
-        
+
         # Verify register_model was not called
         mock_register.assert_not_called()
 
@@ -73,6 +70,6 @@ def test_model_registry_not_provided():
     """Test that no registry loading occurs when litellm_model_registry is not provided."""
     with patch("litellm.register_model") as mock_register:
         model = LitellmModel(model_name="gpt-4o")
-        
+
         # Verify register_model was not called
         mock_register.assert_not_called()

--- a/tests/models/test_litellm_model.py
+++ b/tests/models/test_litellm_model.py
@@ -42,15 +42,15 @@ def test_model_registry_loading():
             "mode": "chat",
         }
     }
-
+    
     with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
         json.dump(model_costs, f)
         registry_path = f.name
-
+    
     try:
         with patch("litellm.register_model") as mock_register:
-            model = LitellmModel(model_name="my-custom-model", litellm_model_registry=registry_path)
-
+            _model = LitellmModel(model_name="my-custom-model", litellm_model_registry=registry_path)
+            
             # Verify register_model was called with the correct data
             mock_register.assert_called_once_with(model_costs)
     finally:
@@ -60,8 +60,8 @@ def test_model_registry_loading():
 def test_model_registry_none():
     """Test that no registry loading occurs when litellm_model_registry is None."""
     with patch("litellm.register_model") as mock_register:
-        model = LitellmModel(model_name="gpt-4", litellm_model_registry=None)
-
+        _model = LitellmModel(model_name="gpt-4", litellm_model_registry=None)
+        
         # Verify register_model was not called
         mock_register.assert_not_called()
 
@@ -69,7 +69,7 @@ def test_model_registry_none():
 def test_model_registry_not_provided():
     """Test that no registry loading occurs when litellm_model_registry is not provided."""
     with patch("litellm.register_model") as mock_register:
-        model = LitellmModel(model_name="gpt-4o")
-
+        _model = LitellmModel(model_name="gpt-4o")
+        
         # Verify register_model was not called
         mock_register.assert_not_called()

--- a/tests/models/test_litellm_model.py
+++ b/tests/models/test_litellm_model.py
@@ -48,11 +48,14 @@ def test_model_registry_loading():
         registry_path = f.name
 
     try:
-        with patch("litellm.register_model") as mock_register:
-            _model = LitellmModel(model_name="my-custom-model", litellm_model_registry=registry_path)
+        with patch("litellm.utils.register_model") as mock_register:
+            _model = LitellmModel(model_name="my-custom-model", litellm_model_registry=Path(registry_path))
 
             # Verify register_model was called with the correct data
             mock_register.assert_called_once_with(model_costs)
+    except Exception as e:
+        print(e)
+        raise e
     finally:
         Path(registry_path).unlink()
 


### PR DESCRIPTION
In LitellmModelConfig, we add a litellm_model_registry field.
When set, we update the `litellm` registry with `litellm.register_model`.
This allows us to add models that aren't registered or outdated in the [litellm default registry](https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json).