### PR TITLE
[WIP] Refactor textual confirmation prompt to allow more user input (human mode, restart etc.)

### DIFF
--- a/docs/reference/agents/textual.md
+++ b/docs/reference/agents/textual.md
@@ -10,7 +10,7 @@
 
 ::: minisweagent.agents.interactive_textual.AgentApp
 
-::: minisweagent.agents.interactive_textual.ConfirmationPromptContainer
+::: minisweagent.agents.interactive_textual.SmartInputContainer
 
 ::: minisweagent.agents.interactive_textual.AddLogEmitCallback
 

--- a/docs/usage/mini_v.md
+++ b/docs/usage/mini_v.md
@@ -45,8 +45,9 @@ Useful switches:
 
 - `confirm` (`c`): The LM proposes an action and the user is prompted to confirm (press Enter)) or reject (enter a rejection message))
 - `yolo` (`y`): The action from the LM is executed immediately without confirmation
+- `human` (`u`): The user is prompted to enter a command directly
 
-You can switch between the modes at any time by pressing the `c` or `y` keys.
+You can switch between the modes at any time by pressing the `c`, `y`, or `u` keys.
 
 `mini -v` starts in `confirm` mode by default. To start in `yolo` mode, you can add `-y`/`--yolo` to the command line.
 

--- a/src/minisweagent/agents/interactive_textual.py
+++ b/src/minisweagent/agents/interactive_textual.py
@@ -206,6 +206,14 @@ class SmartInputContainer(Container):
             event.stop()
             text = self._multi_input.text.strip()
             self._complete_input(text)
+            return
+
+        if event.key == "escape":
+            event.prevent_default()
+            event.stop()
+            self.can_focus = False
+            self._app.set_focus(None)
+            return
 
 
 class AgentApp(App):

--- a/src/minisweagent/agents/interactive_textual.py
+++ b/src/minisweagent/agents/interactive_textual.py
@@ -105,7 +105,7 @@ class SmartInputContainer(Container):
 
         self._prompt_display = Static("", id="prompt-display", classes="prompt-display")
         self._mode_indicator = Static(
-            "Single-line mode ([bold]Enter[/bold] to submit, [bold]Escape[/bold] to switch to multi-line)",
+            "Single-line mode ([bold]Enter[/bold] to submit, [bold]Ctrl+T[/bold] to switch to multi-line)",
             id="mode-indicator",
             classes="mode-indicator",
         )
@@ -163,11 +163,11 @@ class SmartInputContainer(Container):
         self._app.update_content()
 
     def action_toggle_mode(self) -> None:
-        """Toggle between single-line and multi-line modes."""
-        if self.pending_prompt is None:
+        """Switch from single-line to multi-line mode (one-way only)."""
+        if self.pending_prompt is None or self._multiline_mode:
             return
 
-        self._multiline_mode = not self._multiline_mode
+        self._multiline_mode = True
         self._update_mode_display()
         self.on_focus()
 
@@ -178,16 +178,13 @@ class SmartInputContainer(Container):
             self._single_input.display = False
             self._multi_input.display = True
 
-            self._mode_indicator.update(
-                "Multi-line mode ([bold]Ctrl+D[/bold] to submit, [bold]Escape[/bold] to switch to single-line)"
-            )
+            self._mode_indicator.update("Multi-line mode ([bold]Ctrl+D[/bold] to submit)")
         else:
-            self._single_input.value = "".join(self._multi_input.text.splitlines()[:1])
             self._multi_input.display = False
             self._single_input.display = True
 
             self._mode_indicator.update(
-                "Single-line mode ([bold]Enter[/bold] to submit, [bold]Escape[/bold] to switch to multi-line)"
+                "Single-line mode ([bold]Enter[/bold] to submit, [bold]Ctrl+T[/bold] to switch to multi-line input)"
             )
 
     def on_input_submitted(self, event: Input.Submitted) -> None:
@@ -198,7 +195,7 @@ class SmartInputContainer(Container):
 
     def on_key(self, event: Key) -> None:
         """Handle key events."""
-        if event.key == "escape":
+        if event.key == "ctrl+t" and not self._multiline_mode:
             event.prevent_default()
             event.stop()
             self.action_toggle_mode()

--- a/src/minisweagent/agents/interactive_textual.py
+++ b/src/minisweagent/agents/interactive_textual.py
@@ -61,7 +61,6 @@ class TextualAgent(DefaultAgent):
             self.app.call_from_thread(self.app.on_agent_finished, "ERROR", result)
             return "ERROR", result
         else:
-            print("calling on_agent_finished with", exit_status, result)
             self.app.call_from_thread(self.app.on_agent_finished, exit_status, result)
         return exit_status, result
 
@@ -79,14 +78,11 @@ class TextualAgent(DefaultAgent):
             return super().has_finished(output)
         except Submitted as e:
             if self.config.confirm_exit:
-                print("confirming exit")
                 if new_task := self.app.input_container.request_input(
                     "[bold green]Agent wants to finish.[/bold green] "
                     "[green]Type a comment to give it a new task or press enter to quit.\n"
                 ).strip():
                     raise NonTerminatingException(f"The user added a new task: {new_task}")
-                print("no new task")
-            print("raising Submitted")
             raise e
 
 
@@ -174,7 +170,6 @@ class SmartInputContainer(Container):
 
     def _complete_input(self, input_text: str):
         """Internal method to complete the input process."""
-        print("completing input with", input_text)
         self._input_result = input_text
         self.pending_prompt = None
         self._prompt_display.update("")

--- a/src/minisweagent/agents/interactive_textual.py
+++ b/src/minisweagent/agents/interactive_textual.py
@@ -51,7 +51,9 @@ class TextualAgent(DefaultAgent):
         if self.config.mode == "human":
             human_input = self.app.input_container.request_input("Enter your command:")
             self._current_action_from_human = True
-            return {"content": f"\n```bash\n{human_input}\n```"}
+            msg = {"content": f"\n```bash\n{human_input}\n```"}
+            self.add_message("assistant", msg["content"])
+            return msg
         self._current_action_from_human = False
         return super().query()
 

--- a/src/minisweagent/agents/interactive_textual.py
+++ b/src/minisweagent/agents/interactive_textual.py
@@ -375,16 +375,19 @@ class AgentApp(App):
 
     def action_yolo(self):
         self.agent.config.mode = "yolo"
-        self.input_container._complete_input("")
-        self.notify("YOLO mode enabled - actions will execute immediately")
+        if self.input_container.pending_prompt is not None:
+            self.input_container._complete_input("")  # accept
+        self.notify("YOLO mode enabled - LM actions will execute immediately")
 
     def action_human(self):
+        if self.agent.config.mode == "confirm" and self.input_container.pending_prompt is not None:
+            self.input_container._complete_input("User switched to manual mode, this command will be ignored")
         self.agent.config.mode = "human"
         self.notify("Human mode enabled - you can now type commands directly")
 
     def action_confirm(self):
         self.agent.config.mode = "confirm"
-        self.notify("Confirm mode enabled - actions will require confirmation")
+        self.notify("Confirm mode enabled - LM proposes commands and you confirm/reject them")
 
     def action_next_step(self) -> None:
         self.i_step += 1

--- a/src/minisweagent/agents/interactive_textual.py
+++ b/src/minisweagent/agents/interactive_textual.py
@@ -101,21 +101,21 @@ class ConfirmationPromptContainer(Container):
         self._confirmation_result: str | None = None
 
         # Create UI elements
-        self.rejection_input = TextArea(id="rejection-input")
-        self.rejection_help = Static(
+        self.text_input = TextArea(id="rejection-input")
+        self.text_input_help = Static(
             "Press [bold]Ctrl+D[/bold] to submit rejection message",
             id="rejection-help",
             classes="rejection-help",
         )
-        self.rejection_container = Container(self.rejection_input, self.rejection_help, id="rejection-container")
-        self.rejection_container.display = False
+        self.text_input_container = Container(self.text_input, self.text_input_help, id="rejection-container")
+        self.text_input_container.display = False
 
     def compose(self) -> ComposeResult:
         yield Static(
             "Press [bold]ENTER[/bold] to confirm action or [bold]BACKSPACE[/bold] to reject (or [bold]y[/bold] to toggle YOLO mode)",
             classes="confirmation-prompt",
         )
-        yield self.rejection_container
+        yield self.text_input_container
 
     def request_confirmation(self, action: str) -> str | None:
         """Request confirmation for an action. Returns rejection message or None."""
@@ -132,8 +132,8 @@ class ConfirmationPromptContainer(Container):
         self._pending_action = None
         self.display = False
         self.rejecting = False
-        self.rejection_container.display = False
-        self.rejection_input.text = ""
+        self.text_input_container.display = False
+        self.text_input.text = ""
         # Reset agent state to RUNNING after confirmation is completed
         if rejection_message is None:
             self._app.agent_state = "RUNNING"
@@ -143,7 +143,7 @@ class ConfirmationPromptContainer(Container):
     def on_key(self, event: Key) -> None:
         if self.rejecting and event.key == "ctrl+d":
             event.prevent_default()
-            self._complete_confirmation(self.rejection_input.text)
+            self._complete_confirmation(self.text_input.text)
             return
         if not self.rejecting:
             if event.key == "enter":
@@ -152,8 +152,8 @@ class ConfirmationPromptContainer(Container):
             elif event.key == "backspace":
                 event.prevent_default()
                 self.rejecting = True
-                self.rejection_container.display = True
-                self.rejection_input.focus()
+                self.text_input_container.display = True
+                self.text_input.focus()
 
 
 class AgentApp(App):

--- a/src/minisweagent/agents/interactive_textual.py
+++ b/src/minisweagent/agents/interactive_textual.py
@@ -61,6 +61,7 @@ class TextualAgent(DefaultAgent):
             self.app.call_from_thread(self.app.on_agent_finished, "ERROR", result)
             return "ERROR", result
         else:
+            print("calling on_agent_finished with", exit_status, result)
             self.app.call_from_thread(self.app.on_agent_finished, exit_status, result)
         return exit_status, result
 
@@ -78,11 +79,14 @@ class TextualAgent(DefaultAgent):
             return super().has_finished(output)
         except Submitted as e:
             if self.config.confirm_exit:
+                print("confirming exit")
                 if new_task := self.app.input_container.request_input(
                     "[bold green]Agent wants to finish.[/bold green] "
                     "[green]Type a comment to give it a new task or press enter to quit.\n"
                 ).strip():
                     raise NonTerminatingException(f"The user added a new task: {new_task}")
+                print("no new task")
+            print("raising Submitted")
             raise e
 
 
@@ -170,6 +174,7 @@ class SmartInputContainer(Container):
 
     def _complete_input(self, input_text: str):
         """Internal method to complete the input process."""
+        print("completing input with", input_text)
         self._input_result = input_text
         self.pending_prompt = None
         self._prompt_display.update("")

--- a/src/minisweagent/agents/interactive_textual.py
+++ b/src/minisweagent/agents/interactive_textual.py
@@ -185,6 +185,8 @@ class AgentApp(App):
         self.exit_status: str | None = None
         self.result: str | None = None
 
+        self._vscroll = VerticalScroll()
+
     # --- Basics ---
 
     @property
@@ -197,13 +199,13 @@ class AgentApp(App):
         """Set current step index, automatically clamping to valid bounds."""
         if value != self._i_step:
             self._i_step = max(0, min(value, self.n_steps - 1))
-            self.query_one(VerticalScroll).scroll_to(y=0, animate=False)
+            self._vscroll.scroll_to(y=0, animate=False)
             self.update_content()
 
     def compose(self) -> ComposeResult:
         yield Header()
         with Container(id="main"):
-            with VerticalScroll():
+            with self._vscroll:
                 yield Vertical(id="content")
             yield self.confirmation_container
         yield Footer()
@@ -217,8 +219,7 @@ class AgentApp(App):
     # --- Reacting to events ---
 
     def on_message_added(self) -> None:
-        vs = self.query_one(VerticalScroll)
-        auto_follow = self.i_step == self.n_steps - 1 and vs.scroll_target_y <= 1
+        auto_follow = self.i_step == self.n_steps - 1 and self._vscroll.scroll_target_y <= 1
         self.n_steps = len(_messages_to_steps(self.agent.messages))
         self.update_content()
         if auto_follow:
@@ -310,9 +311,7 @@ class AgentApp(App):
         self.i_step = self.n_steps - 1
 
     def action_scroll_down(self) -> None:
-        vs = self.query_one(VerticalScroll)
-        vs.scroll_to(y=vs.scroll_target_y + 15)
+        self._vscroll.scroll_to(y=self._vscroll.scroll_target_y + 15)
 
     def action_scroll_up(self) -> None:
-        vs = self.query_one(VerticalScroll)
-        vs.scroll_to(y=vs.scroll_target_y - 15)
+        self._vscroll.scroll_to(y=self._vscroll.scroll_target_y - 15)

--- a/src/minisweagent/agents/interactive_textual.py
+++ b/src/minisweagent/agents/interactive_textual.py
@@ -159,8 +159,11 @@ class SmartInputContainer(Container):
         self._multiline_mode = False
         self._update_mode_display()
         self._app.agent_state = "RUNNING"
-        self._input_event.set()
         self._app.update_content()
+        # Reset scroll position to bottom since input container disappearing changes layout
+        # somehow scroll_to doesn't work.
+        self._app._vscroll.scroll_y = 0
+        self._input_event.set()
 
     def action_toggle_mode(self) -> None:
         """Switch from single-line to multi-line mode (one-way only)."""
@@ -276,7 +279,7 @@ class AgentApp(App):
     # --- Reacting to events ---
 
     def on_message_added(self) -> None:
-        auto_follow = self.i_step == self.n_steps - 1 and self._vscroll.scroll_target_y <= 1
+        auto_follow = self.i_step == self.n_steps - 1 and self._vscroll.scroll_y <= 1
         self.n_steps = len(_messages_to_steps(self.agent.messages))
         self.update_content()
         if auto_follow:

--- a/src/minisweagent/agents/interactive_textual.py
+++ b/src/minisweagent/agents/interactive_textual.py
@@ -132,18 +132,19 @@ class SmartInputContainer(Container):
         self._input_event = threading.Event()
         self._input_result: str | None = None
 
-        self._prompt_display = Static("", id="prompt-display", classes="prompt-display")
-        self._mode_indicator = Static(
-            "Single-line mode ([bold]Enter[/bold] to submit, [bold]Ctrl+T[/bold] to switch to multi-line)",
-            id="mode-indicator",
-            classes="mode-indicator",
+        self._header_display = Static(
+            "USER INPUT REQUESTED", id="input-header-display", classes="message-header input-request-header"
+        )
+        self._hint_text = Static(
+            "[bold]Enter[/bold] to submit, [bold]Ctrl+T[/bold] to switch to multi-line input, [bold]Tab[/bold] to switch focus with other controls",
+            id="hint-text",
+            classes="hint-text",
         )
         self._single_input = Input(placeholder="Type your input...")
         self._multi_input = TextArea("", show_line_numbers=False, classes="multi-input")
 
         self._input_elements_container = Container(
-            self._prompt_display,
-            self._mode_indicator,
+            self._hint_text,
             self._single_input,
             self._multi_input,
             id="input-elements-container",
@@ -151,7 +152,7 @@ class SmartInputContainer(Container):
 
     def compose(self) -> ComposeResult:
         with Vertical(classes="message-container"):
-            yield Static("USER INPUT REQUESTED", classes="message-header input-request-header")
+            yield self._header_display
             yield self._input_elements_container
 
     def on_mount(self) -> None:
@@ -171,7 +172,7 @@ class SmartInputContainer(Container):
         self._input_event.clear()
         self._input_result = None
         self.pending_prompt = prompt
-        self._prompt_display.update(prompt)
+        self._header_display.update(prompt)
         self._update_mode_display()
         self._app.call_from_thread(self._app.update_content)
         self._input_event.wait()
@@ -181,7 +182,7 @@ class SmartInputContainer(Container):
         """Internal method to complete the input process."""
         self._input_result = input_text
         self.pending_prompt = None
-        self._prompt_display.update("")
+        self._header_display.update("USER INPUT REQUESTED")
         self.display = False
         self._single_input.value = ""
         self._multi_input.text = ""
@@ -210,14 +211,9 @@ class SmartInputContainer(Container):
             self._single_input.display = False
             self._multi_input.display = True
 
-            self._mode_indicator.update("Multi-line mode ([bold]Ctrl+D[/bold] to submit)")
         else:
             self._multi_input.display = False
             self._single_input.display = True
-
-            self._mode_indicator.update(
-                "Single-line mode ([bold]Enter[/bold] to submit, [bold]Ctrl+T[/bold] to switch to multi-line input)"
-            )
 
     def on_input_submitted(self, event: Input.Submitted) -> None:
         """Handle single-line input submission."""

--- a/src/minisweagent/agents/interactive_textual.py
+++ b/src/minisweagent/agents/interactive_textual.py
@@ -191,7 +191,7 @@ class SmartInputContainer(Container):
             )
         else:
             print("Enable Singleline mode")
-            self.single_input.value = self.multi_input.text
+            self.single_input.value = "".join(self.multi_input.text.splitlines()[:1])
             self.multi_input.display = False
             self.single_input.display = True
 

--- a/src/minisweagent/agents/interactive_textual.py
+++ b/src/minisweagent/agents/interactive_textual.py
@@ -387,6 +387,8 @@ class AgentApp(App):
 
     def action_confirm(self):
         self.agent.config.mode = "confirm"
+        if self.agent.config.mode == "human" and self.input_container.pending_prompt is not None:
+            self.input_container._complete_input("")  # just submit blank action
         self.notify("Confirm mode enabled - LM proposes commands and you confirm/reject them")
 
     def action_next_step(self) -> None:

--- a/src/minisweagent/agents/interactive_textual.py
+++ b/src/minisweagent/agents/interactive_textual.py
@@ -197,20 +197,16 @@ class SmartInputContainer(Container):
         """Handle key events."""
         if event.key == "ctrl+t" and not self._multiline_mode:
             event.prevent_default()
-            event.stop()
             self.action_toggle_mode()
             return
 
         if self._multiline_mode and event.key == "ctrl+d":
             event.prevent_default()
-            event.stop()
-            text = self._multi_input.text.strip()
-            self._complete_input(text)
+            self._complete_input(self._multi_input.text.strip())
             return
 
         if event.key == "escape":
             event.prevent_default()
-            event.stop()
             self.can_focus = False
             self._app.set_focus(None)
             return

--- a/src/minisweagent/agents/interactive_textual.py
+++ b/src/minisweagent/agents/interactive_textual.py
@@ -107,7 +107,7 @@ class SmartInputContainer(Container):
         # Create UI elements
         self.prompt_display = Static("", id="prompt-display", classes="prompt-display")
         self.mode_indicator = Static(
-            "Single-line mode (Enter to submit, Escape to switch to multi-line)",
+            "Single-line mode ([bold]Enter[/bold] to submit, [bold]Escape[/bold] to switch to multi-line)",
             id="mode-indicator",
             classes="mode-indicator",
         )
@@ -120,7 +120,9 @@ class SmartInputContainer(Container):
         )
 
     def compose(self) -> ComposeResult:
-        yield self.input_elements_container
+        with Vertical(classes="message-container"):
+            yield Static("[yellow]USER INPUT REQUESTED[/]", classes="message-header")
+            yield self.input_elements_container
 
     def on_mount(self) -> None:
         """Initialize the widget state."""
@@ -184,14 +186,18 @@ class SmartInputContainer(Container):
             self.single_input.display = False
             self.multi_input.display = True
 
-            self.mode_indicator.update("Multi-line mode (Ctrl+D to submit, Escape to switch to single-line)")
+            self.mode_indicator.update(
+                "Multi-line mode ([bold]Ctrl+D[/bold] to submit, [bold]Escape[/bold] to switch to single-line)"
+            )
         else:
             print("Enable Singleline mode")
             self.single_input.value = self.multi_input.text
             self.multi_input.display = False
             self.single_input.display = True
 
-            self.mode_indicator.update("Single-line mode (Enter to submit, Escape to switch to multi-line)")
+            self.mode_indicator.update(
+                "Single-line mode ([bold]Enter[/bold] to submit, [bold]Escape[/bold] to switch to multi-line)"
+            )
 
     def on_input_submitted(self, event: Input.Submitted) -> None:
         """Handle single-line input submission."""
@@ -269,8 +275,9 @@ class AgentApp(App):
         yield Header()
         with Container(id="main"):
             with self._vscroll:
-                yield Vertical(id="content")
-            yield self.input_container
+                with Vertical(id="content"):
+                    pass
+                yield self.input_container
         yield Footer()
 
     def on_mount(self) -> None:

--- a/src/minisweagent/agents/interactive_textual.py
+++ b/src/minisweagent/agents/interactive_textual.py
@@ -137,23 +137,21 @@ class SmartInputContainer(Container):
         )
         self._hint_text = Static(
             "[bold]Enter[/bold] to submit, [bold]Ctrl+T[/bold] to switch to multi-line input, [bold]Tab[/bold] to switch focus with other controls",
-            id="hint-text",
             classes="hint-text",
         )
         self._single_input = Input(placeholder="Type your input...")
         self._multi_input = TextArea("", show_line_numbers=False, classes="multi-input")
 
-        self._input_elements_container = Container(
+        self._input_elements_container = Vertical(
+            self._header_display,
             self._hint_text,
             self._single_input,
             self._multi_input,
-            id="input-elements-container",
+            classes="message-container",
         )
 
     def compose(self) -> ComposeResult:
-        with Vertical(classes="message-container"):
-            yield self._header_display
-            yield self._input_elements_container
+        yield self._input_elements_container
 
     def on_mount(self) -> None:
         """Initialize the widget state."""

--- a/src/minisweagent/agents/interactive_textual.py
+++ b/src/minisweagent/agents/interactive_textual.py
@@ -65,8 +65,10 @@ class TextualAgent(DefaultAgent):
         return exit_status, result
 
     def execute_action(self, action: dict) -> dict:
-        if self.config.mode == "confirm" and not any(
-            re.match(r, action["action"]) for r in self.config.whitelist_actions
+        if (
+            self.config.mode == "confirm"
+            and action["action"].strip()
+            and not any(re.match(r, action["action"]) for r in self.config.whitelist_actions)
         ):
             result = self.app.input_container.request_input("Press ENTER to confirm or provide rejection reason")
             if result:  # Non-empty string means rejection
@@ -381,9 +383,9 @@ class AgentApp(App):
         self.notify("Human mode enabled - you can now type commands directly")
 
     def action_confirm(self):
-        self.agent.config.mode = "confirm"
         if self.agent.config.mode == "human" and self.input_container.pending_prompt is not None:
             self.input_container._complete_input("")  # just submit blank action
+        self.agent.config.mode = "confirm"
         self.notify("Confirm mode enabled - LM proposes commands and you confirm/reject them")
 
     def action_next_step(self) -> None:

--- a/src/minisweagent/config/mini.tcss
+++ b/src/minisweagent/config/mini.tcss
@@ -39,10 +39,10 @@ Footer {
     text-style: bold;
 }
 
-.mode-indicator {
+.hint-text{
     margin-bottom: 1;
     padding: 0 1;
-    color: $accent;
+    color: white;
 }
 
 .message-container {

--- a/src/minisweagent/config/mini.tcss
+++ b/src/minisweagent/config/mini.tcss
@@ -60,6 +60,10 @@ Footer {
     text-style: bold;
 }
 
+.input-request-header {
+    color: $warning;
+}
+
 .message-content {
     margin-top: 1;
     padding: 0 1;

--- a/src/minisweagent/config/mini.tcss
+++ b/src/minisweagent/config/mini.tcss
@@ -1,12 +1,13 @@
 Screen {
     layout: grid;
     grid-size: 1;
-    grid-rows: 1fr 8 1fr;
+    grid-rows: auto 1fr auto;
 }
 
 #main {
     height: 100%;
     padding: 1;
+    layout: vertical;
 }
 
 Footer {
@@ -16,6 +17,32 @@ Footer {
 
 #content {
     height: auto;
+    min-height: 0;
+}
+
+#input-container {
+    height: auto;
+    margin-top: 0;
+    padding: 0;
+    min-height: 0;
+}
+
+#multi-input {
+    height: auto;
+    max-height: 20;
+    min-height: 3;
+}
+
+.prompt-display {
+    margin-bottom: 1;
+    padding: 0 1;
+    text-style: bold;
+}
+
+.mode-indicator {
+    margin-bottom: 1;
+    padding: 0 1;
+    color: $accent;
 }
 
 .message-container {

--- a/src/minisweagent/config/mini.tcss
+++ b/src/minisweagent/config/mini.tcss
@@ -20,14 +20,14 @@ Footer {
     min-height: 0;
 }
 
-#input-container {
+.smart-input-container {
     height: auto;
     margin-top: 0;
     padding: 0;
     min-height: 0;
 }
 
-#multi-input {
+.multi-input {
     height: auto;
     max-height: 20;
     min-height: 3;
@@ -73,29 +73,6 @@ Header.running {
     background: $error;
 }
 
-.confirmation-modal {
-    layout: vertical;
-    background: $surface;
-    margin: 1 4;
-    min-width: 40;
-    padding: 1;
-    border: tall $primary;
-    height: auto;
-}
-
-.modal-title {
-    text-align: center;
-    text-style: bold;
-    margin-bottom: 1;
-}
-
-.modal-content {
-    margin: 1 2;
-    min-height: 1;
-    max-height: 10;
-    overflow-y: auto;
-}
-
 .button-container {
     layout: horizontal;
     align-horizontal: center;
@@ -105,54 +82,4 @@ Header.running {
 .button-container Button {
     margin: 0 1;
     min-width: 10;
-}
-
-.confirmation-container {
-    background: $boost;
-    border: heavy $primary;
-    padding: 1;
-    margin: 1;
-}
-
-.confirmation-header {
-    color: $warning;
-    text-style: bold;
-}
-
-.command-to-confirm {
-    background: $surface;
-    margin: 1 0;
-    padding: 1;
-    color: $text;
-}
-
-#confirmation-input {
-    margin-top: 1;
-}
-
-.confirmation-prompt {
-    background: $boost;
-    border: heavy $warning;
-    padding: 1;
-    margin: 1;
-    text-align: center;
-    color: $warning;
-}
-
-.confirmation-prompt:focus {
-    border: heavy $accent;
-    background: $panel;
-}
-
-#rejection-input {
-    margin: 1;
-}
-
-.rejection-help {
-    background: $boost;
-    border: heavy $warning;
-    padding: 1;
-    margin: 1;
-    text-align: center;
-    color: $warning;
 }

--- a/src/minisweagent/config/mini.tcss
+++ b/src/minisweagent/config/mini.tcss
@@ -114,7 +114,6 @@ Header.running {
 }
 
 #rejection-input {
-    display: none;
     margin: 1;
 }
 

--- a/src/minisweagent/run/mini.py
+++ b/src/minisweagent/run/mini.py
@@ -107,7 +107,7 @@ def main(
     config["agent"]["mode"] = "confirm" if not yolo else "yolo"
     if cost_limit:
         config["agent"]["cost_limit"] = cost_limit
-    if not visual and exit_immediately:
+    if exit_immediately:
         config["agent"]["confirm_exit"] = False
     model = get_model(model_name, config.get("model", {}))
     env = LocalEnvironment(**config.get("env", {}))

--- a/tests/agents/test_interactive_textual.py
+++ b/tests/agents/test_interactive_textual.py
@@ -68,6 +68,7 @@ async def test_everything_integration_test():
         mode="confirm",
         cost_limit=10.0,
     )
+    assert app.agent.config.confirm_exit
     async with app.run_test() as pilot:
         assert app.agent_state == "RUNNING"
         assert "You are a helpful assistant that can do anything." in get_screen_text(app)
@@ -134,16 +135,18 @@ async def test_everything_integration_test():
         assert pilot.app.agent.config.mode == "confirm"  # type: ignore[attr-defined]
         await pilot.press("y")
         assert pilot.app.agent.config.mode == "yolo"  # type: ignore[attr-defined]
-        await pilot.press("enter")  # still need to confirm once for step 3
+        # await pilot.press("enter")  # still need to confirm once for step 3
         # next action will be executed automatically, so we see step 6 next
         await pilot.pause(0.2)
         assert "Step 8/8" in app.title
         assert "echo 'MINI_SWE_AGENT_FINAL_OUTPUT'" in get_screen_text(app)
         # await pilot.pause(0.1)
-        assert "STOPPED" in app.title
-        assert "press enter" not in get_screen_text(app).lower()
+        # assert "press enter" not in get_screen_text(app).lower()
+        print(get_screen_text(app))
+        assert "AWAITING_INPUT" in app.title  # still waiting for confirmation of exit
 
         print(">>> Directly navigate to step 1")
+        await pilot.press("escape")
         await pilot.press("0")
         assert "Step 1/8" in app.title
         assert "You are a helpful assistant that can do anything." in get_screen_text(app)
@@ -337,6 +340,7 @@ async def test_agent_successful_completion_notification():
         env=LocalEnvironment(),
         task="Completion test",
         mode="yolo",
+        confirm_exit=False,
     )
 
     # Mock the notify method to capture calls
@@ -410,6 +414,7 @@ async def test_scrolling_behavior():
         env=LocalEnvironment(),
         task="Scroll test",
         mode="yolo",
+        confirm_exit=False,
     )
 
     async with app.run_test() as pilot:

--- a/tests/agents/test_interactive_textual.py
+++ b/tests/agents/test_interactive_textual.py
@@ -130,15 +130,35 @@ async def test_everything_integration_test():
         assert "Step 5/5" in app.title
         assert "echo '4'" in get_screen_text(app)
 
+        print(">>> Switch tohuman mode")
+        await pilot.press("escape")
+        await pilot.press("u")
+
+        assert pilot.app.agent.config.mode == "human"  # type: ignore[attr-defined]
+        await pilot.pause(0.2)
+        print(get_screen_text(app))
+        assert "User switched to manual mode, this command will be ignored" in get_screen_text(app)
+        assert "Enter your command" in get_screen_text(app)
+        assert "Step 5/5" in app.title  # we didn't move because waiting for human command
+
+        print(">>> Human gives command")
+        await type_text(pilot, "echo 'human'")
+        await pilot.press("enter")
+        await pilot.pause(0.2)
+        print(get_screen_text(app))
+        assert "Step 6/6" in app.title
+        assert "human" in get_screen_text(app)  # show the observation
+
         print(">>> Enter yolo mode & confirm")
         await pilot.press("escape")
-        assert pilot.app.agent.config.mode == "confirm"  # type: ignore[attr-defined]
+        assert pilot.app.agent.config.mode == "human"  # type: ignore[attr-defined]
         await pilot.press("y")
+        # Note that this will add one step, because we're basically now executing an empty human action
         assert pilot.app.agent.config.mode == "yolo"  # type: ignore[attr-defined]
         # await pilot.press("enter")  # still need to confirm once for step 3
         # next action will be executed automatically, so we see step 6 next
         await pilot.pause(0.2)
-        assert "Step 8/8" in app.title
+        assert "Step 10/10" in app.title
         assert "echo 'MINI_SWE_AGENT_FINAL_OUTPUT'" in get_screen_text(app)
         # await pilot.pause(0.1)
         # assert "press enter" not in get_screen_text(app).lower()
@@ -148,12 +168,12 @@ async def test_everything_integration_test():
         print(">>> Directly navigate to step 1")
         await pilot.press("escape")
         await pilot.press("0")
-        assert "Step 1/8" in app.title
+        assert "Step 1/10" in app.title
         assert "You are a helpful assistant that can do anything." in get_screen_text(app)
 
-        print(">>> Directly navigate to step 8")
+        print(">>> Directly navigate to step 9")
         await pilot.press("$")
-        assert "Step 8/8" in app.title
+        assert "Step 10/10" in app.title
         assert "MINI_SWE_AGENT_FINAL_OUTPUT" in get_screen_text(app)
 
 

--- a/tests/agents/test_interactive_textual.py
+++ b/tests/agents/test_interactive_textual.py
@@ -599,25 +599,6 @@ async def test_smart_input_container_initialization():
         assert isinstance(container._input_event, threading.Event)
 
 
-async def test_smart_input_container_compose():
-    """Test that compose method exists and can be called in proper context."""
-    app = DummyTestApp()
-    async with app.run_test():
-        container = create_mock_smart_input_container(app)
-
-        # Since compose requires proper Textual context, we just verify the method exists
-        # and has the expected signature
-        assert hasattr(container, "compose")
-        assert callable(container.compose)
-
-        # Test that the container has the expected child widgets
-        assert hasattr(container, "_prompt_display")
-        assert hasattr(container, "_mode_indicator")
-        assert hasattr(container, "_single_input")
-        assert hasattr(container, "_multi_input")
-        assert hasattr(container, "_input_elements_container")
-
-
 async def test_smart_input_container_request_input():
     """Test request_input method behavior."""
     app = DummyTestApp()
@@ -857,41 +838,6 @@ async def test_smart_input_container_key_events_no_action():
         # Should not prevent default or complete input
         assert not mock_event.prevent_default.called
         assert not container._complete_input.called
-
-
-async def test_smart_input_container_update_mode_display():
-    """Test mode display updates correctly."""
-    app = DummyTestApp()
-    async with app.run_test():
-        container = SmartInputContainer(app)
-
-        # Mock the display properties and update method
-        container._single_input.display = True
-        container._multi_input.display = True
-        container._mode_indicator.update = Mock()
-
-        # Test single-line mode display
-        container._multiline_mode = False
-        container._update_mode_display()
-
-        assert container._single_input.display is True
-        assert container._multi_input.display is False
-        expected_single_msg = (
-            "Single-line mode ([bold]Enter[/bold] to submit, [bold]Ctrl+T[/bold] to switch to multi-line input)"
-        )
-        container._mode_indicator.update.assert_called_with(expected_single_msg)
-
-        # Reset and test multiline mode display
-        container._mode_indicator.update.reset_mock()
-        container._single_input.value = "test input"
-        container._multiline_mode = True
-        container._update_mode_display()
-
-        assert container._single_input.display is False
-        assert container._multi_input.display is True
-        assert container._multi_input.text == "test input"
-        expected_multi_msg = "Multi-line mode ([bold]Ctrl+D[/bold] to submit)"
-        container._mode_indicator.update.assert_called_with(expected_multi_msg)
 
 
 async def test_smart_input_container_on_focus():

--- a/tests/agents/test_interactive_textual.py
+++ b/tests/agents/test_interactive_textual.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import threading
 from unittest.mock import Mock
@@ -60,7 +61,8 @@ async def test_everything_integration_test():
                 "THOUGHTT 4\n ```bash\necho '4'\n```",  # step 5
                 "THOUGHTT 5\n ```bash\necho '5'\n```",  # step 6
                 "THOUGHTT 6\n ```bash\necho '6'\n```",  # step 7
-                "FINISHING\n ```bash\necho 'MINI_SWE_AGENT_FINAL_OUTPUT'\n```",  # step 8
+                "FINISHING\n ```bash\necho 'MINI_SWE_AGENT_FINAL_OUTPUT'\n```",
+                "FINISHING2\n ```bash\necho 'MINI_SWE_AGENT_FINAL_OUTPUT'\n```",
             ],
         ),
         env=LocalEnvironment(),
@@ -175,6 +177,20 @@ async def test_everything_integration_test():
         await pilot.press("$")
         assert "Step 10/10" in app.title
         assert "MINI_SWE_AGENT_FINAL_OUTPUT" in get_screen_text(app)
+
+        print(">>> Give it a new task")
+        assert "to give it a new task" in get_screen_text(app).lower()
+        await type_text(pilot, "New task")
+        await pilot.press("enter")
+        await pilot.pause(0.2)
+
+        print(">>> Exit confirmation should appear again")
+        assert "Step 11/11" in app.title
+        # assert "New task" in get_screen_text(app)
+        assert "to give it a new task" in get_screen_text(app).lower()
+        await pilot.press("enter")
+        await pilot.pause(0.2)
+        assert "STOPPED" in app.title
 
 
 def test_messages_to_steps_edge_cases():
@@ -920,7 +936,3 @@ async def test_smart_input_container_on_mount():
         # Check initialization
         assert container._multi_input.display is False
         assert container._update_mode_display.called
-
-
-# Import asyncio for the async tests
-import asyncio

--- a/tests/agents/test_interactive_textual.py
+++ b/tests/agents/test_interactive_textual.py
@@ -233,8 +233,7 @@ async def test_confirmation_rejection_with_message():
         assert app.confirmation_container.rejecting is True
 
         # Type rejection message
-        rejection_input = app.confirmation_container.query_one("#rejection-input")
-        rejection_input.text = "Not safe to run"  # type: ignore[attr-defined]
+        app.confirmation_container.rejection_input.text = "Not safe to run"  # type: ignore[attr-defined]
 
         # Submit rejection
         await pilot.press("ctrl+d")

--- a/tests/agents/test_interactive_textual.py
+++ b/tests/agents/test_interactive_textual.py
@@ -233,7 +233,7 @@ async def test_confirmation_rejection_with_message():
         assert app.confirmation_container.rejecting is True
 
         # Type rejection message
-        app.confirmation_container.rejection_input.text = "Not safe to run"  # type: ignore[attr-defined]
+        app.confirmation_container.text_input.text = "Not safe to run"  # type: ignore[attr-defined]
 
         # Submit rejection
         await pilot.press("ctrl+d")

--- a/tests/run/test_cli_integration.py
+++ b/tests/run/test_cli_integration.py
@@ -563,47 +563,6 @@ def test_no_exit_immediately_flag_sets_confirm_exit_true():
         assert agent.config.confirm_exit is True
 
 
-def test_exit_immediately_flag_only_affects_non_visual_mode():
-    """Test that --exit-immediately flag only affects non-visual mode."""
-    with (
-        patch("minisweagent.run.mini.configure_if_first_time"),
-        patch("minisweagent.run.mini.run_textual") as mock_run_textual,
-        patch("minisweagent.run.mini.get_model") as mock_get_model,
-        patch("minisweagent.run.mini.LocalEnvironment") as mock_env,
-        patch("minisweagent.run.mini.get_config_path") as mock_get_config_path,
-        patch("minisweagent.run.mini.yaml.safe_load") as mock_yaml_load,
-    ):
-        # Setup mocks
-        mock_model = Mock()
-        mock_get_model.return_value = mock_model
-        mock_environment = Mock()
-        mock_env.return_value = mock_environment
-        mock_config_path = Mock()
-        mock_config_path.read_text.return_value = ""
-        mock_get_config_path.return_value = mock_config_path
-        mock_yaml_load.return_value = {"agent": {"system_template": "test"}, "env": {}, "model": {}}
-        mock_run_textual.return_value = Mock()
-
-        # Call main function in visual mode with --exit-immediately flag
-        main(
-            config_spec=DEFAULT_CONFIG,
-            model_name="test-model",
-            task="Test task",
-            yolo=False,
-            output=None,
-            visual=True,  # Visual mode
-            exit_immediately=True,
-        )
-
-        # Verify run_textual was called and confirm_exit is NOT set in config
-        # (because the logic only applies to non-visual mode)
-        mock_run_textual.assert_called_once()
-        args, kwargs = mock_run_textual.call_args
-        agent_config = args[2]  # agent config is the third argument
-        # In visual mode, confirm_exit should not be set by the --exit-immediately flag
-        assert "confirm_exit" not in agent_config
-
-
 def test_exit_immediately_flag_with_typer_runner():
     """Test --exit-immediately flag using typer's test runner."""
     from typer.testing import CliRunner


### PR DESCRIPTION
In reference to

#142 
#89

* [x] Add human mode switch
* [x] Add confirmation before quit
* [x] Update docs
* [x] Make sure test coverage is 100%
* [x] Remove print statements
* [x] Bug: Switching confirm -> human auto-confirms LM action
* [x] Do we properly add messages for human commands?