### PR TITLE
Add container timeout to docker environment

### DIFF
--- a/src/minisweagent/environments/docker.py
+++ b/src/minisweagent/environments/docker.py
@@ -24,6 +24,8 @@ class DockerEnvironmentConfig:
     """Path to the docker/container executable."""
     run_args: list[str] = field(default_factory=list)
     """Additional arguments to pass to the docker/container executable."""
+    container_timeout: str = "2h"
+    """Max duration to keep container running. Uses the same format as the sleep command."""
 
 
 class DockerEnvironment:
@@ -49,7 +51,7 @@ class DockerEnvironment:
             *self.config.run_args,
             self.config.image,
             "sleep",
-            "infinity",  # Keep container running
+            self.config.container_timeout,
         ]
         print(f"Starting container with command: {shlex.join(cmd)}")
         result = subprocess.run(


### PR DESCRIPTION
In the `DockerEnvironmentConfig`, we add a `container_timeout` that sets the sleep duration for the container on startup.
This allows one to set a "global task timeout" for tasks as a fallback to automatically clean up orphaned containers if Python crashes or gets killed for some reason, or if a model is taking an inordinate amount of time to complete a task.

I set the default value to `2h` which I think is a sensible value, but this can be set back to `infinity` if we want preserve existing behavior.