### PR TITLE
Make it possible to run swebench in the singularity environment

### DIFF
--- a/docs/blog/posts/gpt5.md
+++ b/docs/blog/posts/gpt5.md
@@ -127,7 +127,7 @@ So the real winner in my opinion is `GPT-5-mini`!
     Check out our [notes](../../quickstart.md#gpt-5) on how to run `mini` with GPT-5.
 
     You can reproduce our numbers in this blog by following the [swebench](../../usage/swebench.md) tutorial, but
-    the tl;dr is to run (remove the temperature setting from the `swebench.yaml` file first, 
+    the tl;dr is to run (remove the temperature setting from the `swebench.yaml` file first,
     because it's not supported by the `GPT-5-*` models):
 
     ```bash

--- a/src/minisweagent/environments/singularity.py
+++ b/src/minisweagent/environments/singularity.py
@@ -65,7 +65,7 @@ class SingularityEnvironment:
         return {"output": result.stdout, "returncode": result.returncode}
 
     def cleanup(self):
-        if os.path.exists(self.sandbox_dir):
+        if Path.exists(self.sandbox_dir):
             print(f"Removing sandbox {self.sandbox_dir}")
             shutil.rmtree(self.sandbox_dir)
 

--- a/src/minisweagent/environments/singularity.py
+++ b/src/minisweagent/environments/singularity.py
@@ -2,10 +2,10 @@
 
 import os
 import subprocess
-from dataclasses import dataclass, field
 import tempfile
-from typing import Any
 import uuid
+from dataclasses import dataclass, field
+from typing import Any
 
 
 @dataclass

--- a/src/minisweagent/environments/singularity.py
+++ b/src/minisweagent/environments/singularity.py
@@ -65,7 +65,7 @@ class SingularityEnvironment:
         return {"output": result.stdout, "returncode": result.returncode}
 
     def cleanup(self):
-        if Path.exists(self.sandbox_dir):
+        if self.sandbox_dir.exists():
             print(f"Removing sandbox {self.sandbox_dir}")
             shutil.rmtree(self.sandbox_dir)
 

--- a/src/minisweagent/environments/singularity.py
+++ b/src/minisweagent/environments/singularity.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
 
 import os
+import shutil
 import subprocess
 import tempfile
 import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
-import shutil
 from typing import Any
 
 

--- a/src/minisweagent/run/extra/swebench.py
+++ b/src/minisweagent/run/extra/swebench.py
@@ -82,7 +82,7 @@ def get_swebench_docker_image_name(instance: dict) -> str:
 
 
 def get_environment(environment_type: EnvironmentType | None, config: dict, instance: dict):
-    if not type or environment_type == EnvironmentType.docker:
+    if not environment_type or environment_type == EnvironmentType.docker:
         return DockerEnvironment(
             **(config.get("environment", {}) | {"image": get_swebench_docker_image_name(instance)})
         )

--- a/src/minisweagent/run/extra/swebench.py
+++ b/src/minisweagent/run/extra/swebench.py
@@ -4,13 +4,13 @@
 # Read this first: https://mini-swe-agent.com/latest/usage/swebench/  (usage docs)
 
 import concurrent.futures
-from enum import Enum
 import json
 import random
 import re
 import threading
 import time
 import traceback
+from enum import Enum
 from pathlib import Path
 
 import typer
@@ -79,7 +79,6 @@ def get_swebench_docker_image_name(instance: dict) -> str:
         id_docker_compatible = iid.replace("__", "_1776_")
         image_name = f"swebench/sweb.eval.x86_64.{id_docker_compatible}:latest".lower()
     return image_name
-
 
 
 def get_environment(environment_type: EnvironmentType | None, config: dict, instance: dict):

--- a/src/minisweagent/run/extra/swebench_single.py
+++ b/src/minisweagent/run/extra/swebench_single.py
@@ -16,9 +16,11 @@ from minisweagent.run.extra.swebench import DATASET_MAPPING, get_swebench_docker
 
 app = typer.Typer(add_completion=False)
 
+
 class Environment(str, Enum):
     docker = "docker"
     singularity = "singularity"
+
 
 @app.command()
 def main(
@@ -47,10 +49,17 @@ def main(
 
     _config = yaml.safe_load(get_config_path(config_path).read_text())
     if not environment or environment == Environment.docker:
-        env = DockerEnvironment(**(_config.get("environment", {}) | {"image": get_swebench_docker_image_name(instance)}))
+        env = DockerEnvironment(
+            **(_config.get("environment", {}) | {"image": get_swebench_docker_image_name(instance)})
+        )
     else:
         assert environment == Environment.singularity
-        env = SingularityEnvironment(**(_config.get("environment", {}) | {"image": "docker://" + get_swebench_docker_image_name(instance), "cwd": "/testbed"}))
+        env = SingularityEnvironment(
+            **(
+                _config.get("environment", {})
+                | {"image": "docker://" + get_swebench_docker_image_name(instance), "cwd": "/testbed"}
+            )
+        )
     agent = InteractiveAgent(
         get_model(model_name, _config.get("model", {})),
         env,

--- a/src/minisweagent/run/extra/swebench_single.py
+++ b/src/minisweagent/run/extra/swebench_single.py
@@ -1,6 +1,5 @@
 """Run on a single SWE-Bench instance."""
 
-from enum import Enum
 from pathlib import Path
 
 import typer
@@ -12,15 +11,9 @@ from minisweagent.config import builtin_config_dir, get_config_path
 from minisweagent.environments.docker import DockerEnvironment
 from minisweagent.environments.singularity import SingularityEnvironment
 from minisweagent.models import get_model
-from minisweagent.run.extra.swebench import DATASET_MAPPING, get_swebench_docker_image_name
+from minisweagent.run.extra.swebench import DATASET_MAPPING, EnvironmentType, get_environment, get_swebench_docker_image_name
 
 app = typer.Typer(add_completion=False)
-
-
-class Environment(str, Enum):
-    docker = "docker"
-    singularity = "singularity"
-
 
 @app.command()
 def main(
@@ -31,7 +24,7 @@ def main(
     config_path: Path = typer.Option(
         builtin_config_dir / "extra" / "swebench.yaml", "-c", "--config", help="Path to a config file"
     ),
-    environment: Environment | None = typer.Option(None, "-e", "--environment"),
+    environment: EnvironmentType | None = typer.Option(None, "-e", "--environment"),
 ) -> None:
     """Run on a single SWE-Bench instance."""
     try:
@@ -48,18 +41,7 @@ def main(
     instance: dict = instances[instance_spec]  # type: ignore
 
     _config = yaml.safe_load(get_config_path(config_path).read_text())
-    if not environment or environment == Environment.docker:
-        env = DockerEnvironment(
-            **(_config.get("environment", {}) | {"image": get_swebench_docker_image_name(instance)})
-        )
-    else:
-        assert environment == Environment.singularity
-        env = SingularityEnvironment(
-            **(
-                _config.get("environment", {})
-                | {"image": "docker://" + get_swebench_docker_image_name(instance), "cwd": "/testbed"}
-            )
-        )
+    env = get_environment(environment, _config, instance)
     agent = InteractiveAgent(
         get_model(model_name, _config.get("model", {})),
         env,

--- a/src/minisweagent/run/extra/swebench_single.py
+++ b/src/minisweagent/run/extra/swebench_single.py
@@ -8,12 +8,15 @@ from datasets import load_dataset
 
 from minisweagent.agents.interactive import InteractiveAgent
 from minisweagent.config import builtin_config_dir, get_config_path
-from minisweagent.environments.docker import DockerEnvironment
-from minisweagent.environments.singularity import SingularityEnvironment
 from minisweagent.models import get_model
-from minisweagent.run.extra.swebench import DATASET_MAPPING, EnvironmentType, get_environment, get_swebench_docker_image_name
+from minisweagent.run.extra.swebench import (
+    DATASET_MAPPING,
+    EnvironmentType,
+    get_environment,
+)
 
 app = typer.Typer(add_completion=False)
+
 
 @app.command()
 def main(


### PR DESCRIPTION
Fixes https://github.com/SWE-agent/mini-swe-agent/issues/386

Since singularity containers are read only by default, this creates a sandbox https://apptainer.org/docs/user/main/cli/apptainer_build.html in which the commands are executed.
