### PR TITLE
feat: Graceful handling of unknown models in LitellmModel

### DIFF
--- a/tests/models/test_unknown_model_handling.py
+++ b/tests/models/test_unknown_model_handling.py
@@ -1,0 +1,76 @@
+"""Test that LitellmModel handles unknown models gracefully."""
+
+from unittest.mock import MagicMock, patch
+
+from minisweagent.models.litellm_model import LitellmModel, _warned_models
+
+
+def test_unknown_model_graceful_handling():
+    """Test that unknown models work without crashing and show warnings."""
+    # Clear any previous warnings
+    _warned_models.clear()
+
+    # Create a mock response that would normally fail cost calculation
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock()]
+    mock_response.choices[0].message.content = "Test response"
+
+    with patch("minisweagent.models.litellm_model.litellm.completion") as mock_completion:
+        mock_completion.return_value = mock_response
+
+        # This model doesn't exist in litellm's registry
+        model = LitellmModel(model_name="unknown/test-model")
+
+        # Should work without crashing
+        result = model.query([{"role": "user", "content": "test"}])
+
+        assert result["content"] == "Test response"
+        assert model.n_calls == 1
+        assert model.unknown_model_calls == 1
+        assert model.cost == 0  # Cost should be 0 for unknown models
+
+        # Should have warned about this model
+        assert "unknown/test-model" in _warned_models
+
+
+def test_known_model_still_tracks_cost():
+    """Test that known models still track cost properly."""
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock()]
+    mock_response.choices[0].message.content = "Test response"
+
+    with patch("minisweagent.models.litellm_model.litellm.completion") as mock_completion:
+        mock_completion.return_value = mock_response
+
+        with patch("minisweagent.models.litellm_model.litellm.cost_calculator.completion_cost") as mock_cost:
+            mock_cost.return_value = 0.001  # $0.001
+
+            model = LitellmModel(model_name="gpt-3.5-turbo")
+            result = model.query([{"role": "user", "content": "test"}])
+
+            assert result["content"] == "Test response"
+            assert model.n_calls == 1
+            assert model.unknown_model_calls == 0  # Should not increment for known models
+            assert model.cost == 0.001  # Cost should be tracked
+
+
+def test_warning_only_shown_once_per_model():
+    """Test that warning is only shown once per model."""
+    _warned_models.clear()
+
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock()]
+    mock_response.choices[0].message.content = "Test response"
+
+    with patch("minisweagent.models.litellm_model.litellm.completion") as mock_completion:
+        mock_completion.return_value = mock_response
+
+        model = LitellmModel(model_name="unknown/test-model-2")
+
+        # First call should add to warned models
+        model.query([{"role": "user", "content": "test"}])
+        assert "unknown/test-model-2" in _warned_models
+
+        # Second call should not warn again (just checking it doesn't crash)
+        model.query([{"role": "user", "content": "test"}])
+        assert model.unknown_model_calls == 2


### PR DESCRIPTION
## Summary
This PR makes mini-swe-agent work seamlessly with any OpenRouter model (or other providers) even when the model isn't in litellm's pricing registry. Instead of crashing, it continues working and provides helpful guidance.

## Problem
Currently, when using models not in litellm's registry (like many OpenRouter models), mini-swe-agent crashes with:
```
ValueError: This model isn't mapped yet. Add it here - https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json
```

This is frustrating for users who just want to try a new model quickly.

## Solution
- Wrap cost calculation in try/except
- Continue with cost=0 if model is unknown  
- Show a helpful warning (once per model) explaining how to enable cost tracking
- Track how many calls were made without cost info

## Benefits
1. **Just works** - Any model from any provider works immediately
2. **Helpful** - Clear instructions for users who want cost tracking
3. **Minimal** - ~20 lines, fits mini-swe-agent's philosophy
4. **Non-intrusive** - Only warns once per model, not every call

## Testing
Added comprehensive tests in `test_unknown_model_handling.py`:
- ✅ Unknown models work without registry file
- ✅ Shows helpful warning on first use only
- ✅ Known models still track costs properly
- ✅ Tracks unknown_model_calls metric

Tested with real OpenRouter kimi-k2 model.

## Example Output
```
⚠️  Cost tracking unavailable for 'openrouter/moonshotai/kimi-k2'
   To enable cost tracking, create a model registry file:
   1. Create model_registry.json with your model's pricing
   2. Set LITELLM_MODEL_REGISTRY_PATH=/path/to/model_registry.json
   See: https://docs.litellm.ai/docs/proxy/custom_pricing
```

## Related Issues
Addresses the need for "Support for more models (anything where litellm doesn't work out of the box)" mentioned in contributing.md.

This aligns with mini-swe-agent's philosophy: minimalistic, hackable, and practical.