### PR TITLE
Fix: Preserve newlines in agent output to prevent patch errors

### DIFF
--- a/src/minisweagent/agents/default.py
+++ b/src/minisweagent/agents/default.py
@@ -124,6 +124,6 @@ class DefaultAgent:
 
     def has_finished(self, output: dict[str, str]):
         """Raises Submitted exception with final output if the agent has finished its task."""
-        lines = output.get("output", "").lstrip().splitlines()
+        lines = output.get("output", "").lstrip().splitlines(keepends=True)
         if lines and lines[0].strip() in ["MINI_SWE_AGENT_FINAL_OUTPUT", "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT"]:
-            raise Submitted("\n".join(lines[1:]))
+            raise Submitted("".join(lines[1:]))


### PR DESCRIPTION
This minimal change modifies the `has_finished` method to preserve original line endings when processing output. Previously, splitlines() would strip newlines, causing patches that originally end with a newline to lose it. This leads to "patch unexpectedly ends in middle of line" errors in quite a few cases, when running local evaluation via swe-bench.

Changes:
- Add keepends=True to splitlines() to preserve original line endings
- Change from '\n'.join() to ''.join() to maintain exact formatting

Fixes #305

<!--
Thanks for contributing a pull request, we appreciate you!

If this PR fixes an issue, please reference it, e.g., 'Fixes #1234'.

You can delete this comment.
-->
