### PR TITLE
change swe-rex env usage to set merge_output_streams True

### DIFF
--- a/src/minisweagent/environments/extra/swerex_docker.py
+++ b/src/minisweagent/environments/extra/swerex_docker.py
@@ -29,11 +29,11 @@ class SwerexDockerEnvironment:
         output = asyncio.run(
             self.deployment.runtime.execute(
                 RexCommand(
-                    command=command, shell=True, check=False, cwd=cwd or self.config.cwd, timeout=self.config.timeout
+                    command=command, shell=True, check=False, cwd=cwd or self.config.cwd, timeout=self.config.timeout, merge_output_streams=True,
                 )
             )
         )
         return {
-            "output": f"<stdout>\n{output.stdout}</stdout>\n<stderr>\n{output.stderr}</stderr>",
+            "output": output.stdout,
             "returncode": output.exit_code,
         }

--- a/src/minisweagent/environments/extra/swerex_docker.py
+++ b/src/minisweagent/environments/extra/swerex_docker.py
@@ -29,7 +29,12 @@ class SwerexDockerEnvironment:
         output = asyncio.run(
             self.deployment.runtime.execute(
                 RexCommand(
-                    command=command, shell=True, check=False, cwd=cwd or self.config.cwd, timeout=self.config.timeout, merge_output_streams=True,
+                    command=command,
+                    shell=True,
+                    check=False,
+                    cwd=cwd or self.config.cwd,
+                    timeout=self.config.timeout,
+                    merge_output_streams=True,
                 )
             )
         )


### PR DESCRIPTION
This change depends on updates introduced in swe-agent/swe-rex#238 .
Upon merging that PR, we should merge this one, and set a new minimum swe-rex version in the requirements.

This sets `merge_output_streams` to True when invoking RexCommand for the swerex_docker environment. Currently, the non-multiplexed format is incompatible with `has_finished` disallowing agents to actually complete tasks in swe-bench.