### PR TITLE
[apptainer / singularity] Retry building the sandbox if it fails

### DIFF
--- a/src/minisweagent/environments/singularity.py
+++ b/src/minisweagent/environments/singularity.py
@@ -41,6 +41,7 @@ class SingularityEnvironment:
                 subprocess.run(
                     [self.config.executable, "build", "--sandbox", self.sandbox_dir, self.config.image],
                     check=True,
+                    capture_output=True,
                 )
                 break
             except subprocess.CalledProcessError:

--- a/src/minisweagent/environments/singularity.py
+++ b/src/minisweagent/environments/singularity.py
@@ -47,7 +47,9 @@ class SingularityEnvironment:
             except subprocess.CalledProcessError as e:
                 self.cleanup()
                 if attempt == max_retries - 1:
-                    self.logger.error(f"Error building image {self.config.image}, stdout: {e.stdout}, stderr: {e.stderr}")
+                    self.logger.error(
+                        f"Error building image {self.config.image}, stdout: {e.stdout}, stderr: {e.stderr}"
+                    )
                     raise
 
     def get_template_vars(self) -> dict[str, Any]:

--- a/src/minisweagent/environments/singularity.py
+++ b/src/minisweagent/environments/singularity.py
@@ -44,8 +44,10 @@ class SingularityEnvironment:
                     capture_output=True,
                 )
                 break
-            except subprocess.CalledProcessError:
+            except subprocess.CalledProcessError as e:
+                self.cleanup()
                 if attempt == max_retries - 1:
+                    self.logger.error(f"Error building image {self.config.image}, stdout: {e.stdout}, stderr: {e.stderr}")
                     raise
 
     def get_template_vars(self) -> dict[str, Any]:

--- a/src/minisweagent/environments/singularity.py
+++ b/src/minisweagent/environments/singularity.py
@@ -23,6 +23,8 @@ class SingularityEnvironmentConfig:
     """Timeout for executing commands in the container."""
     executable: str = os.getenv("MSWEA_SINGULARITY_EXECUTABLE", "singularity")
     """Path to the singularity executable."""
+    sandbox_build_retries: int = 3
+    """Number of retries for building the sandbox if an error occurs."""
 
 
 class SingularityEnvironment:
@@ -32,25 +34,28 @@ class SingularityEnvironment:
         """Singularity environment. See `SingularityEnvironmentConfig` for kwargs."""
         self.logger = logger or logging.getLogger("minisweagent.environment")
         self.config = config_class(**kwargs)
+        self.sandbox_dir = self._build_sandbox()
 
+    def _build_sandbox(self) -> Path:
         # Building the sandbox can fail (very rarely), so we retry it
-        max_retries = 3
+        max_retries = self.config.sandbox_build_retries
         for attempt in range(max_retries):
-            self.sandbox_dir = Path(tempfile.gettempdir()) / f"minisweagent-{uuid.uuid4().hex[:8]}"
+            sandbox_dir = Path(tempfile.gettempdir()) / f"minisweagent-{uuid.uuid4().hex[:8]}"
             try:
                 subprocess.run(
-                    [self.config.executable, "build", "--sandbox", self.sandbox_dir, self.config.image],
+                    [self.config.executable, "build", "--sandbox", sandbox_dir, self.config.image],
                     check=True,
                     capture_output=True,
                 )
                 break
             except subprocess.CalledProcessError as e:
-                self.cleanup()
+                shutil.rmtree(sandbox_dir, ignore_errors=True)
+                self.logger.error(
+                    f"Error building image {self.config.image}, stdout: {e.stdout}, stderr: {e.stderr} (attempt {attempt + 1}/{max_retries})"
+                )
                 if attempt == max_retries - 1:
-                    self.logger.error(
-                        f"Error building image {self.config.image}, stdout: {e.stdout}, stderr: {e.stderr}"
-                    )
                     raise
+        return sandbox_dir
 
     def get_template_vars(self) -> dict[str, Any]:
         return asdict(self.config)
@@ -85,8 +90,7 @@ class SingularityEnvironment:
         return {"output": result.stdout, "returncode": result.returncode}
 
     def cleanup(self):
-        if self.sandbox_dir.exists():
-            shutil.rmtree(self.sandbox_dir)
+        shutil.rmtree(self.sandbox_dir, ignore_errors=True)
 
     def __del__(self):
         """Cleanup sandbox when object is destroyed."""


### PR DESCRIPTION
Very rarely, building the apptainer sandbox will fail with a transient error, the ones I have seen are:

```
FATAL:   While performing build: conveyor failed to get: error writing layer: stream error: stream ID 9; INTERNAL_ERROR; received from peer
```

and

```
FATAL:   While performing build: conveyor failed to get: unexpected end of JSON input
```

This PR adds a retry loop with a small number of retries around the build step to make sure such error won't disrupt building and running the environment.

I also added `capture_output=True` so the progress bars on the terminal won't get disrupted by the build output, and added logging in the rare cases where the error is not transient (the case where this happens in my setup is if the provisioned disk is not large enough).