### PR TITLE
Add image-prefix argument to mini-extra to enable use of custom docker images

### DIFF
--- a/tests/run/test_swebench.py
+++ b/tests/run/test_swebench.py
@@ -88,6 +88,22 @@ def test_get_image_name_with_complex_instance_id():
     assert get_swebench_docker_image_name(instance) == expected
 
 
+def test_get_image_name_with_ghcr_custom_image_prefix():
+    """Test get_image_name with ghcr image_prefix argument. Image name should be unchanged"""
+    instance = {"instance_id": "swe-agent__test-repo__1"}
+    prefix = "ghcr.io/epoch-research/swe-bench.eval.x86_64"
+    expected = f"{prefix}.swe-agent__test-repo__1:latest"
+    assert get_swebench_docker_image_name(instance, image_prefix=prefix) == expected
+
+
+def test_get_image_name_with_non_ghcr_custom_image_prefix():
+    """Test get_image_name with non-ghcr image_prefix argument. Image name should be modified with 1776"""
+    instance = {"instance_id": "swe-agent__test-repo__1"}
+    prefix = "docker.io/epoch-research/swe-bench.eval.x86_64"
+    expected = f"{prefix}.swe-agent_1776_test-repo_1776_1:latest"
+    assert get_swebench_docker_image_name(instance, image_prefix=prefix) == expected
+
+
 def test_filter_instances_no_filters():
     """Test filter_instances with no filtering applied"""
     instances = [{"instance_id": "repo1__test1"}, {"instance_id": "repo2__test2"}, {"instance_id": "repo3__test3"}]


### PR DESCRIPTION
Hi there. This PR adds an `--image-prefix` argument to the mini-extra cli so that it can be run against custom docker images. The driver for this is the desire to use the optimized [epoch.ai](https://epoch.ai/blog/swebench-docker) docker images with the mini agent. Due the way they are layered the total run time for SWE-bench comes down significantly. If you are open to accepting this PR I will create a similar one for the SWE-bench repo to enable the same for evaluation runs.

Thanks