### PR TITLE
feat: Add OpenAI Responses API support

### DIFF
--- a/src/minisweagent/config/extra/swebench.yaml
+++ b/src/minisweagent/config/extra/swebench.yaml
@@ -228,3 +228,21 @@ model:
   model_kwargs:
     drop_params: true
     temperature: 0.0
+
+  # Uncomment to use OpenAI models with Chat Completions API
+  # model_name: "gpt-5-mini"
+  # response_api_mode: "off"
+  # model_kwargs:
+  #   drop_params: true
+  #   reasoning_effort: "medium"
+  #   verbosity: "medium"
+
+  # Uncomment to use OpenAI models with Responses API
+  # model_name: "gpt-5-mini"
+  # response_api_mode: "on"
+  # model_kwargs:
+  #   drop_params: true
+  #   reasoning:
+  #     effort: "medium"
+  #   text:
+  #     verbosity: "medium"

--- a/src/minisweagent/models/litellm_model.py
+++ b/src/minisweagent/models/litellm_model.py
@@ -3,9 +3,10 @@ import logging
 import os
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 import litellm
+from openai.types.responses.response_output_message import ResponseOutputMessage
 from tenacity import (
     before_sleep_log,
     retry,
@@ -24,6 +25,7 @@ class LitellmModelConfig:
     model_name: str
     model_kwargs: dict[str, Any] = field(default_factory=dict)
     litellm_model_registry: Path | str | None = os.getenv("LITELLM_MODEL_REGISTRY_PATH")
+    response_api_mode: Literal["off", "on"] = "off"
 
 
 class LitellmModel:
@@ -31,6 +33,7 @@ class LitellmModel:
         self.config = LitellmModelConfig(**kwargs)
         self.cost = 0.0
         self.n_calls = 0
+        self._previous_response_id: str | None = None
         if self.config.litellm_model_registry and Path(self.config.litellm_model_registry).is_file():
             litellm.utils.register_model(json.loads(Path(self.config.litellm_model_registry).read_text()))
 
@@ -52,15 +55,30 @@ class LitellmModel:
     )
     def _query(self, messages: list[dict[str, str]], **kwargs):
         try:
-            return litellm.completion(
-                model=self.config.model_name, messages=messages, **(self.config.model_kwargs | kwargs)
+            if self.config.response_api_mode == "off":
+                return litellm.completion(
+                    model=self.config.model_name, messages=messages, **(self.config.model_kwargs | kwargs)
+                )
+
+            resp = litellm.responses(
+                model=self.config.model_name,
+                input=messages if self._previous_response_id is None else messages[-1:],
+                previous_response_id=self._previous_response_id,
+                **(self.config.model_kwargs | kwargs),
             )
+
+            self._previous_response_id = getattr(resp, "id", None)
+            return resp
         except litellm.exceptions.AuthenticationError as e:
             e.message += " You can permanently set your API key with `mini-extra config set KEY VALUE`."
             raise e
 
     def query(self, messages: list[dict[str, str]], **kwargs) -> dict:
         response = self._query(messages, **kwargs)
+        if self.config.response_api_mode == "off":
+            text = response.choices[0].message.content or ""  # type: ignore
+        else:
+            text = self._coerce_responses_text(response)
         try:
             cost = litellm.cost_calculator.completion_cost(response)
         except Exception as e:
@@ -74,8 +92,19 @@ class LitellmModel:
         self.cost += cost
         GLOBAL_MODEL_STATS.add(cost)
         return {
-            "content": response.choices[0].message.content or "",  # type: ignore
+            "content": text,
         }
+
+    # Helper to normalize LiteLLM Responses API result to text
+    def _coerce_responses_text(self, resp: Any) -> str:
+        # openai client directly returns `output_text`, but litellm doesn't support it yet.
+        text = getattr(resp, "output_text", None)
+        if isinstance(text, str) and text:
+            return text
+
+        # Concatenate all (to be consistent with openai client)
+        output = [item.content[0].text for item in resp.output if isinstance(item, ResponseOutputMessage)]
+        return "\n\n".join(output) or ""
 
     def get_template_vars(self) -> dict[str, Any]:
         return asdict(self.config) | {"n_model_calls": self.n_calls, "model_cost": self.cost}


### PR DESCRIPTION
## Summary

This PR implements support for OpenAI's Responses API in mini-swe-agent, addressing issue https://github.com/SWE-agent/mini-swe-agent/issues/459.

## Changes

- **Add `response_api_mode` configuration option** to `LitellmModelConfig` (off/on)
- **Implement OpenAI Responses API integration** with conversation continuity via `previous_response_id`
- **Add helper method `_coerce_responses_text`** for response normalization between Chat and Responses APIs
- **Update `swebench.yaml` config** with commented examples for both Chat and Responses API configurations
- **Support reasoning/verbosity parameters** for GPT-5-mini models

## Configuration Examples

Users can now uncomment the relevant sections in `src/minisweagent/config/extra/swebench.yaml`:

**Chat Completions API:**
```yaml
model_name: "gpt-5-mini"
response_api_mode: "off"
model_kwargs:
  drop_params: true
  reasoning_effort: "medium"
  verbosity: "medium"
```

**Responses API:**
```yaml
model_name: "gpt-5-mini"  
response_api_mode: "on"
model_kwargs:
  drop_params: true
  reasoning:
    effort: "medium"
  text:
    verbosity: "medium"
```

## Experimental Results

Conducted comprehensive experiments with GPT models using `steps_limit = 50`:

### Default Settings (reasoning = medium, verbosity = medium)
- **GPT-5-mini Chat API (run 1)**: 299/500 resolved (59.8%), $19.49

- **GPT-5-mini Responses API (run 1)**: 272/500 resolved (54.4%), $31.25  
- **GPT-5-mini Responses API (run 2)**: 276/500 resolved (55.2%), $31.54

### High Reasoning Settings (reasoning = high, verbosity = medium)
- **GPT-5-mini Chat API (run 1)**: 321/500 resolved (64.2%), $48.76
- **GPT-5-mini Chat API (run 2)**: 326/500 resolved (65.2%), $44.62

- **GPT-5-mini Responses API (run 1)**: 276/500 resolved (55.2%), $60.76

### GPT-5 (reasoning = medium, verbosity = medium)
- **GPT-5 Responses API**: 325/500 resolved (65.0%), $152.54

## Key Observations

### Responses API vs. Chat API Performance
- **GPT-5-mini**: Responses API shows **lower performance** (~55% vs ~60%) and **higher cost** than Chat API when reasoning effort is either medium or high.
- **GPT-5**: Responses API achieves **similar performance** (65.0%) and cost (~$140) as compared to what's reported in SWE-bench blog posts

Note: This differs from OpenAI's blog post findings ([reasoning_items](https://cookbook.openai.com/examples/responses_api/reasoning_items)) which reported ~3% improvement on SWE-bench with Responses API.

**Possible explanation**: mini-swe-agent's design of "Thought + ONE command" per step may make raw reasoning tokens redundant to "Thought" and less useful for subsequent turns. The longer context from reasoning tokens (as evidenced by higher cost) in case of Responses API may actually hurt GPT-5-mini performance. GPT-5 doesn't shows a performance drop with Responses API, likely due to its better ability to deal with longer context length.

### Reasoning Level Impact  
- **GPT-5-mini with high reasoning**: 64.6% solve rate at $46.69 (averaged over two runs)
- **GPT-5**: 65.0% solve rate at ~$150
- **Cost efficiency**: GPT-5-mini with high reasoning achieves similar performance at **1/3 the cost** of GPT-5. I think it is worth sharing with the large audience of mini-swe-agent for more cost-efficient experiments @klieret 

## Open Question
I have provided a possible explanation on the worse performance of Responses API than Chat API in case of gpt-5-mini . However, the exact reason remains an open question and it will be great to have more study on this. 

## Next Step
Responses API is stateful by default. We might want to further add a stateless support for folks who must or prefer to follow ZDR (zero-data retention), e.g., as a mode called "on-zdr." In such case, it involves keeping a local conversation history in Responses format and a design decision of whether to implement it in `src/minisweagent/models/litellm_model.py` or `src/minisweagent/agents/default.py`.

## Testing

- ✅ Maintains backward compatibility (default `response_api_mode: "off"`)
- ✅ Successfully integrates with existing LiteLLM model infrastructure  
- ✅ Tested with both GPT-5-mini and GPT-5 models
- ✅ Pre-commit hooks pass

## Testing

Addresses #459