### PR TITLE
Enh: Add a timeout argument as an override for `env.execute`

### DIFF
--- a/src/minisweagent/environments/docker.py
+++ b/src/minisweagent/environments/docker.py
@@ -73,7 +73,7 @@ class DockerEnvironment:
         self.logger.info(f"Started container {container_name} with ID {result.stdout.strip()}")
         self.container_id = result.stdout.strip()
 
-    def execute(self, command: str, cwd: str = "", timeout: int | None = None) -> dict[str, Any]:
+    def execute(self, command: str, cwd: str = "", *, timeout: int | None = None) -> dict[str, Any]:
         """Execute a command in the Docker container and return the result as a dict."""
         cwd = cwd or self.config.cwd
         assert self.container_id, "Container not started"
@@ -89,7 +89,7 @@ class DockerEnvironment:
         result = subprocess.run(
             cmd,
             text=True,
-            timeout=timeout if timeout is not None else self.config.timeout,
+            timeout=timeout or self.config.timeout,
             encoding="utf-8",
             errors="replace",
             stdout=subprocess.PIPE,

--- a/src/minisweagent/environments/extra/bubblewrap.py
+++ b/src/minisweagent/environments/extra/bubblewrap.py
@@ -77,7 +77,7 @@ class BubblewrapEnvironment:
         self.working_dir = Path(tempfile.gettempdir()) / f"minisweagent-{uuid.uuid4().hex[:8]}"
         self.working_dir.mkdir(parents=True)
 
-    def execute(self, command: str, cwd: str = "", timeout: int | None = None) -> dict[str, Any]:
+    def execute(self, command: str, cwd: str = "", *, timeout: int | None = None) -> dict[str, Any]:
         """Execute a command in the bubblewrap environment and return the result as a dict."""
         cwd = cwd or self.config.cwd or str(self.working_dir)
 
@@ -92,7 +92,7 @@ class BubblewrapEnvironment:
         result = subprocess.run(
             cmd,
             text=True,
-            timeout=timeout if timeout is not None else self.config.timeout,
+            timeout=timeout or self.config.timeout,
             encoding="utf-8",
             errors="replace",
             stdout=subprocess.PIPE,

--- a/src/minisweagent/environments/extra/swerex_docker.py
+++ b/src/minisweagent/environments/extra/swerex_docker.py
@@ -24,7 +24,7 @@ class SwerexDockerEnvironment:
         self.deployment = DockerDeployment(image=self.config.image, **self.config.deployment_extra_kwargs)
         asyncio.run(self.deployment.start())
 
-    def execute(self, command: str, cwd: str = "", timeout: int | None = None) -> dict[str, Any]:
+    def execute(self, command: str, cwd: str = "", *, timeout: int | None = None) -> dict[str, Any]:
         """Execute a command in the environment and return the raw output."""
         output = asyncio.run(
             self.deployment.runtime.execute(
@@ -33,7 +33,7 @@ class SwerexDockerEnvironment:
                     shell=True,
                     check=False,
                     cwd=cwd or self.config.cwd,
-                    timeout=timeout if timeout is not None else self.config.timeout,
+                    timeout=timeout or self.config.timeout,
                     merge_output_streams=True,
                 )
             )

--- a/src/minisweagent/environments/local.py
+++ b/src/minisweagent/environments/local.py
@@ -17,7 +17,7 @@ class LocalEnvironment:
         """This class executes bash commands directly on the local machine."""
         self.config = config_class(**kwargs)
 
-    def execute(self, command: str, cwd: str = "", timeout: int | None = None):
+    def execute(self, command: str, cwd: str = "", *, timeout: int | None = None):
         """Execute a command in the local environment and return the result as a dict."""
         cwd = cwd or self.config.cwd or os.getcwd()
         result = subprocess.run(
@@ -26,7 +26,7 @@ class LocalEnvironment:
             text=True,
             cwd=cwd,
             env=os.environ | self.config.env,
-            timeout=timeout if timeout is not None else self.config.timeout,
+            timeout=timeout or self.config.timeout,
             encoding="utf-8",
             errors="replace",
             stdout=subprocess.PIPE,

--- a/src/minisweagent/environments/singularity.py
+++ b/src/minisweagent/environments/singularity.py
@@ -60,7 +60,7 @@ class SingularityEnvironment:
     def get_template_vars(self) -> dict[str, Any]:
         return asdict(self.config)
 
-    def execute(self, command: str, cwd: str = "", timeout: int | None = None) -> dict[str, Any]:
+    def execute(self, command: str, cwd: str = "", *, timeout: int | None = None) -> dict[str, Any]:
         """Execute a command in a Singularity container and return the result as a dict."""
         cmd = [self.config.executable, "exec"]
 
@@ -81,7 +81,7 @@ class SingularityEnvironment:
         result = subprocess.run(
             cmd,
             text=True,
-            timeout=timeout if timeout is not None else self.config.timeout,
+            timeout=timeout or self.config.timeout,
             encoding="utf-8",
             errors="replace",
             stdout=subprocess.PIPE,


### PR DESCRIPTION
# What does this PR do?


Adds a `timeout` argument for `env.execute` so that some execute commands can use a different timeout setting than the one provided in the config. 


This will support executing arbitrary commands (like running a test) with Mini-SWE-Agent's Environment class
