### PR TITLE
Handle whitespaces in bash command line

### DIFF
--- a/src/minisweagent/agents/default.py
+++ b/src/minisweagent/agents/default.py
@@ -106,7 +106,7 @@ class DefaultAgent:
 
     def parse_action(self, response: dict) -> dict:
         """Parse the action from the message. Returns the action."""
-        actions = re.findall(r"```bash\n(.*?)\n```", response["content"], re.DOTALL)
+        actions = re.findall(r"```bash\s*\n(.*?)\n```", response["content"], re.DOTALL)
         if len(actions) == 1:
             return {"action": actions[0].strip(), **response}
         raise FormatError(self.render_template(self.config.format_error_template, actions=actions))


### PR DESCRIPTION
I have been having a lot of trouble running mini-extra swebench with a llama.cpp-served version of  Qwen3-Coder 30B. Reviewing the trajectories revealed frequent failure to call bash. The reason was that the LLM frequently added whitespace on the bash backtick line, like so:

"```bash  \n"

and this was not caught by the regex, which expects

"```bash\n"


This PR allows for whitespaces on the bash backtick line. I can't see the harm, it just helps along any formatting issues that the LLM sends. 