### PR TITLE
feat: add Requesty model provider support

### DIFF
--- a/src/minisweagent/models/__init__.py
+++ b/src/minisweagent/models/__init__.py
@@ -76,6 +76,7 @@ _MODEL_CLASS_MAPPING = {
     "litellm": "minisweagent.models.litellm_model.LitellmModel",
     "openrouter": "minisweagent.models.openrouter_model.OpenRouterModel",
     "portkey": "minisweagent.models.portkey_model.PortkeyModel",
+    "requesty": "minisweagent.models.requesty_model.RequestyModel",
     "deterministic": "minisweagent.models.test_models.DeterministicModel",
 }
 

--- a/src/minisweagent/models/requesty_model.py
+++ b/src/minisweagent/models/requesty_model.py
@@ -1,0 +1,119 @@
+import json
+import logging
+import os
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+import requests
+from tenacity import (
+    before_sleep_log,
+    retry,
+    retry_if_not_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
+
+from minisweagent.models import GLOBAL_MODEL_STATS
+
+logger = logging.getLogger("requesty_model")
+
+
+@dataclass
+class RequestyModelConfig:
+    model_name: str
+    model_kwargs: dict[str, Any] = field(default_factory=dict)
+
+
+class RequestyAPIError(Exception):
+    """Custom exception for Requesty API errors."""
+
+    pass
+
+
+class RequestyAuthenticationError(Exception):
+    """Custom exception for Requesty authentication errors."""
+
+    pass
+
+
+class RequestyRateLimitError(Exception):
+    """Custom exception for Requesty rate limit errors."""
+
+    pass
+
+
+class RequestyModel:
+    def __init__(self, **kwargs):
+        self.config = RequestyModelConfig(**kwargs)
+        self.cost = 0.0
+        self.n_calls = 0
+        self._api_url = "https://router.requesty.ai/v1/chat/completions"
+        self._api_key = os.getenv("REQUESTY_API_KEY", "")
+
+    @retry(
+        stop=stop_after_attempt(10),
+        wait=wait_exponential(multiplier=1, min=4, max=60),
+        before_sleep=before_sleep_log(logger, logging.WARNING),
+        retry=retry_if_not_exception_type(
+            (
+                RequestyAuthenticationError,
+                KeyboardInterrupt,
+            )
+        ),
+    )
+    def _query(self, messages: list[dict[str, str]], **kwargs):
+        headers = {
+            "Authorization": f"Bearer {self._api_key}",
+            "Content-Type": "application/json",
+            "HTTP-Referer": "https://github.com/SWE-agent/mini-swe-agent",
+            "X-Title": "mini-swe-agent",
+        }
+
+        payload = {
+            "model": self.config.model_name,
+            "messages": messages,
+            **(self.config.model_kwargs | kwargs),
+        }
+
+        try:
+            response = requests.post(self._api_url, headers=headers, data=json.dumps(payload), timeout=60)
+            response.raise_for_status()
+            return response.json()
+        except requests.exceptions.HTTPError as e:
+            if response.status_code == 401:
+                error_msg = "Authentication failed. You can permanently set your API key with `mini-extra config set REQUESTY_API_KEY YOUR_KEY`."
+                raise RequestyAuthenticationError(error_msg) from e
+            elif response.status_code == 429:
+                raise RequestyRateLimitError("Rate limit exceeded") from e
+            else:
+                raise RequestyAPIError(f"HTTP {response.status_code}: {response.text}") from e
+        except requests.exceptions.RequestException as e:
+            raise RequestyAPIError(f"Request failed: {e}") from e
+
+    def query(self, messages: list[dict[str, str]], **kwargs) -> dict:
+        response = self._query(messages, **kwargs)
+
+        # Extract cost from usage information
+        usage = response.get("usage", {})
+        cost = usage.get("cost", 0.0)
+
+        # If cost is not available, raise an error
+        if cost == 0.0:
+            raise RequestyAPIError(
+                f"No cost information available from Requesty API for model {self.config.model_name}. "
+                "Cost tracking is required but not provided by the API response."
+            )
+
+        self.n_calls += 1
+        self.cost += cost
+        GLOBAL_MODEL_STATS.add(cost)
+
+        return {
+            "content": response["choices"][0]["message"]["content"] or "",
+            "extra": {
+                "response": response,  # already is json
+            },
+        }
+
+    def get_template_vars(self) -> dict[str, Any]:
+        return asdict(self.config) | {"n_model_calls": self.n_calls, "model_cost": self.cost}


### PR DESCRIPTION
- Add RequestyModel class with OpenAI-compatible API support
- Implements cost tracking from API response usage.cost field
- Includes custom headers for GitHub referer and mini-swe-agent title
- Supports all Requesty models via router.requesty.ai/v1 endpoint
- Add requesty to model class mapping for --model-class requesty usage
- Follows same patterns as OpenRouter model implementation
