### PR TITLE
docs: fix a little typo in global_configuration.md

### DIFF
--- a/docs/advanced/global_configuration.md
+++ b/docs/advanced/global_configuration.md
@@ -47,7 +47,7 @@ You can also edit the `.env` file directly and we provide a helper function for 
 mini-extra config edit
 ```
 
-To set environment variables (recommended for temporary experiemntation or API keys):
+To set environment variables (recommended for temporary experimentation or API keys):
 
 ```bash
 export KEY="value"


### PR DESCRIPTION
## Summary
- Fixed typo in [docs/advanced/global_configuration.md](https://github.com/SWE-agent/mini-swe-agent/blob/e3f6b4ba395d858452e4a876086f61069f1b427a/docs/advanced/global_configuration.md?plain=1#L50) line 50. Corrects misspelling: 'experiemntation' → 'experimentation'.