### PR TITLE
docs: Add blog post on how to parallelize mini-swe-agent with Ray

### DIFF
--- a/docs/advanced/cookbook.md
+++ b/docs/advanced/cookbook.md
@@ -292,4 +292,9 @@ An agent that validates actions before execution (also an example of how to use 
     )
     ```
 
+### Running mini-swe-agent on Ray
+
+[This blog post](https://www.anyscale.com/blog/massively-parallel-agentic-simulations-with-ray)
+describes how to parallelize mini-swe-agent runs with Ray.
+
 {% include-markdown "_footer.md" %}


### PR DESCRIPTION
This adds the https://www.anyscale.com/blog/massively-parallel-agentic-simulations-with-ray to the cookbook to show people how to run mini-swe-agent with Ray (following the instructions in https://mini-swe-agent.com/latest/contributing/) 