### PR TITLE
Update default model to claude-sonnet-4-5-20250929

### DIFF
--- a/docs/advanced/cookbook.md
+++ b/docs/advanced/cookbook.md
@@ -38,7 +38,7 @@ You can override the default entry point by setting the `MSWEA_DEFAULT_RUN` envi
     from minisweagent.models import get_model
     from minisweagent.environments.local import LocalEnvironment
 
-    model_name = "anthropic/claude-sonnet-4-20250514"
+    model_name = "anthropic/claude-sonnet-4-5-20250929"
 
     agent = DefaultAgent(
         get_model(model_name=model_name),
@@ -54,7 +54,7 @@ You can override the default entry point by setting the `MSWEA_DEFAULT_RUN` envi
     from minisweagent.models.anthropic_model import AnthropicModel
     from minisweagent.environments.local import LocalEnvironment
 
-    model_name = "anthropic/claude-sonnet-4-20250514"
+    model_name = "anthropic/claude-sonnet-4-5-20250929"
 
     agent = DefaultAgent(
         AnthropicModel(model_name=model_name),

--- a/docs/advanced/global_configuration.md
+++ b/docs/advanced/global_configuration.md
@@ -29,7 +29,7 @@ or to update specific settings:
 ```
 mini-extra config set KEY VALUE
 # e.g.,
-mini-extra config set MSWEA_MODEL_NAME "anthropic/claude-sonnet-4-20250514"
+mini-extra config set MSWEA_MODEL_NAME "anthropic/claude-sonnet-4-5-20250929"
 mini-extra config set MSWEA_MODEL_API_KEY "sk-..."
 ```
 
@@ -64,7 +64,7 @@ setx KEY "value"
 ```bash
 # Default model name
 # (default: not set)
-MSWEA_MODEL_NAME="anthropic/claude-sonnet-4-20250514"
+MSWEA_MODEL_NAME="anthropic/claude-sonnet-4-5-20250929"
 
 # Default API key
 # (default: not set)

--- a/docs/data/all_models.txt
+++ b/docs/data/all_models.txt
@@ -42,6 +42,7 @@ anthropic.claude-instant-v1
 anthropic.claude-opus-4-1-20250805-v1:0
 anthropic.claude-opus-4-20250514-v1:0
 anthropic.claude-sonnet-4-20250514-v1:0
+anthropic.claude-sonnet-4-5-20250929-v1:0
 anthropic.claude-v1
 anthropic.claude-v2
 anthropic.claude-v2:1
@@ -65,6 +66,7 @@ apac.anthropic.claude-3-5-sonnet-20241022-v2:0
 apac.anthropic.claude-3-haiku-20240307-v1:0
 apac.anthropic.claude-3-sonnet-20240229-v1:0
 apac.anthropic.claude-sonnet-4-20250514-v1:0
+apac.anthropic.claude-sonnet-4-5-20250929-v1:0
 assemblyai/best
 assemblyai/nano
 azure/ada
@@ -358,6 +360,7 @@ claude-opus-4-1
 claude-opus-4-1-20250805
 claude-opus-4-20250514
 claude-sonnet-4-20250514
+claude-sonnet-4-5-20250929
 cloudflare/@cf/meta/llama-2-7b-chat-fp16
 cloudflare/@cf/meta/llama-2-7b-chat-int8
 cloudflare/@cf/mistral/mistral-7b-instruct-v0.1
@@ -587,6 +590,7 @@ eu.anthropic.claude-3-sonnet-20240229-v1:0
 eu.anthropic.claude-opus-4-1-20250805-v1:0
 eu.anthropic.claude-opus-4-20250514-v1:0
 eu.anthropic.claude-sonnet-4-20250514-v1:0
+eu.anthropic.claude-sonnet-4-5-20250929-v1:0
 eu.meta.llama3-2-1b-instruct-v1:0
 eu.meta.llama3-2-3b-instruct-v1:0
 eu.mistral.pixtral-large-2502-v1:0
@@ -1325,6 +1329,7 @@ us.anthropic.claude-3-sonnet-20240229-v1:0
 us.anthropic.claude-opus-4-1-20250805-v1:0
 us.anthropic.claude-opus-4-20250514-v1:0
 us.anthropic.claude-sonnet-4-20250514-v1:0
+us.anthropic.claude-sonnet-4-5-20250929-v1:0
 us.deepseek.r1-v1:0
 us.meta.llama3-1-405b-instruct-v1:0
 us.meta.llama3-1-70b-instruct-v1:0

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -91,7 +91,7 @@
     To permanently change it:
 
     ```bash
-    mini-extra config set MSWEA_MODEL_NAME anthropic/claude-sonnet-4-20250514
+    mini-extra config set MSWEA_MODEL_NAME anthropic/claude-sonnet-4-5-20250929
     ```
 
     Alternatively, you can directly edit the `.env` file in the config directory

--- a/docs/models/quickstart.md
+++ b/docs/models/quickstart.md
@@ -94,7 +94,7 @@ There are several ways to set your API keys:
     Here's a few examples of popular models:
 
     ```
-    anthropic/claude-sonnet-4-20250514
+    anthropic/claude-sonnet-4-5-20250929
     openai/gpt-5
     openai/gpt-5-mini
     gemini/gemini-2.5-pro
@@ -125,7 +125,7 @@ Here's a few examples:
 
     ```yaml
     model:
-    model_name: "anthropic/claude-sonnet-4-20250514"
+    model_name: "anthropic/claude-sonnet-4-5-20250929"
       model_kwargs:
         temperature: 0.0
     ```
@@ -201,7 +201,7 @@ For example:
 === "Portkey model"
 
     ```bash
-    mini -m "claude-sonnet-4-20250514" --model-class portkey
+    mini -m "claude-sonnet-4-5-20250929" --model-class portkey
     ```
 
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -130,6 +130,6 @@
 
 !!! success "Which model to use?"
 
-    We recommend using `anthropic/claude-sonnet-4-20250514` for most tasks.
+    We recommend using `anthropic/claude-sonnet-4-5-20250929` for most tasks.
     For openai models, we recommend using `openai/gpt-5` or `openai/gpt-5-mini`.
     You can check scores of different models at our [SWE-bench (bash-only)](https://swebench.com) leaderboard.

--- a/docs/usage/swebench.md
+++ b/docs/usage/swebench.md
@@ -37,7 +37,7 @@
         python src/minisweagent/run/extra/swebench.py --help
         # Example:
         mini-extra swebench \
-            --model anthropic/claude-sonnet-4-20250514 \
+            --model anthropic/claude-sonnet-4-5-20250929 \
             --subset verified \
             --split test \
             --workers 4
@@ -75,13 +75,13 @@
         mini-extra swebench-single \
             --subset verified \
             --split test \
-            --model anthropic/claude-sonnet-4-20250514 \
+            --model anthropic/claude-sonnet-4-5-20250929 \
             -i sympy__sympy-15599
         # or
         mini-extra swebench-single \
             --subset verified \
             --split test \
-            -m anthropic/claude-sonnet-4-20250514 \
+            -m anthropic/claude-sonnet-4-5-20250929 \
             -i 0  # instance index
         ```
 

--- a/src/minisweagent/config/extra/swebench.yaml
+++ b/src/minisweagent/config/extra/swebench.yaml
@@ -224,7 +224,7 @@ environment:
   environment_class: docker
 
 model:
-  model_name: "anthropic/claude-sonnet-4-20250514"
+  model_name: "anthropic/claude-sonnet-4-5-20250929"
   model_kwargs:
     drop_params: true
     temperature: 0.0

--- a/src/minisweagent/config/extra/swebench_roulette.yaml
+++ b/src/minisweagent/config/extra/swebench_roulette.yaml
@@ -227,7 +227,7 @@ model:
   model_name: "roulette"
   model_class: "minisweagent.models.extra.roulette.RouletteModel"
   model_kwargs:
-    - model_name: "anthropic/claude-sonnet-4-20250514"
+    - model_name: "anthropic/claude-sonnet-4-5-20250929"
       model_kwargs:
         temperature: 0.
     - model_name: "gpt-5"

--- a/src/minisweagent/run/extra/config.py
+++ b/src/minisweagent/run/extra/config.py
@@ -33,7 +33,7 @@ This setup will ask you for your model and an API key.
 
 Here's a few popular models and the required API keys:
 
-[bold green]anthropic/claude-sonnet-4-20250514[/bold green] ([bold green]ANTHROPIC_API_KEY[/bold green])
+[bold green]anthropic/claude-sonnet-4-5-20250929[/bold green] ([bold green]ANTHROPIC_API_KEY[/bold green])
 [bold green]openai/gpt-5[/bold green] or [bold green]openai/gpt-5-mini[/bold green] ([bold green]OPENAI_API_KEY[/bold green])
 [bold green]gemini/gemini-2.5-pro[/bold green] ([bold green]GEMINI_API_KEY[/bold green])
 
@@ -58,7 +58,7 @@ def setup():
     """Setup the global config file."""
     console.print(_SETUP_HELP.format(global_config_file=global_config_file))
     default_model = prompt(
-        "Enter your default model (e.g., anthropic/claude-sonnet-4-20250514): ",
+        "Enter your default model (e.g., anthropic/claude-sonnet-4-5-20250929): ",
         default=os.getenv("MSWEA_MODEL_NAME", ""),
     ).strip()
     if default_model:

--- a/tests/run/test_extra_config.py
+++ b/tests/run/test_extra_config.py
@@ -16,14 +16,14 @@ class TestConfigSetup:
             patch("minisweagent.run.extra.config.prompt") as mock_prompt,
             patch("minisweagent.run.extra.config.console.print"),
         ):
-            mock_prompt.side_effect = ["anthropic/claude-sonnet-4-20250514", "ANTHROPIC_API_KEY", "sk-test123"]
+            mock_prompt.side_effect = ["anthropic/claude-sonnet-4-5-20250929", "ANTHROPIC_API_KEY", "sk-test123"]
 
             setup()
 
             # Verify the file was created and contains the expected content
             assert config_file.exists()
             content = config_file.read_text()
-            assert "MSWEA_MODEL_NAME='anthropic/claude-sonnet-4-20250514'" in content
+            assert "MSWEA_MODEL_NAME='anthropic/claude-sonnet-4-5-20250929'" in content
             assert "ANTHROPIC_API_KEY='sk-test123'" in content
             assert "MSWEA_CONFIGURED='true'" in content
 
@@ -115,11 +115,11 @@ class TestConfigSet:
         config_file = tmp_path / ".env"
 
         with patch("minisweagent.run.extra.config.global_config_file", config_file):
-            set("MSWEA_MODEL_NAME", "anthropic/claude-sonnet-4-20250514")
+            set("MSWEA_MODEL_NAME", "anthropic/claude-sonnet-4-5-20250929")
 
             assert config_file.exists()
             content = config_file.read_text()
-            assert "MSWEA_MODEL_NAME='anthropic/claude-sonnet-4-20250514'" in content
+            assert "MSWEA_MODEL_NAME='anthropic/claude-sonnet-4-5-20250929'" in content
 
     def test_set_with_no_arguments_prompts_for_both(self, tmp_path):
         """Test set command when no arguments provided - should prompt for both key and value."""
@@ -179,11 +179,11 @@ class TestConfigSet:
         config_file = tmp_path / ".env"
 
         with patch("minisweagent.run.extra.config.global_config_file", config_file):
-            set("MSWEA_MODEL_NAME", "anthropic/claude-sonnet-4-20250514")
+            set("MSWEA_MODEL_NAME", "anthropic/claude-sonnet-4-5-20250929")
 
             assert config_file.exists()
             content = config_file.read_text()
-            assert "MSWEA_MODEL_NAME='anthropic/claude-sonnet-4-20250514'" in content
+            assert "MSWEA_MODEL_NAME='anthropic/claude-sonnet-4-5-20250929'" in content
 
     def test_set_api_key(self, tmp_path):
         """Test setting an API key."""
@@ -317,7 +317,7 @@ class TestConfigUnset:
         """Test unsetting one key from a file with multiple keys."""
         config_file = tmp_path / ".env"
         config_file.write_text(
-            "MSWEA_MODEL_NAME='anthropic/claude-sonnet-4-20250514'\n"
+            "MSWEA_MODEL_NAME='anthropic/claude-sonnet-4-5-20250929'\n"
             "ANTHROPIC_API_KEY='sk-anthropic-key'\n"
             "OPENAI_API_KEY='sk-openai-key'\n"
             "MSWEA_CONFIGURED='true'\n"
@@ -330,7 +330,7 @@ class TestConfigUnset:
             # Target key should be removed
             assert "ANTHROPIC_API_KEY" not in content
             # Other keys should remain
-            assert "MSWEA_MODEL_NAME='anthropic/claude-sonnet-4-20250514'" in content
+            assert "MSWEA_MODEL_NAME='anthropic/claude-sonnet-4-5-20250929'" in content
             assert "OPENAI_API_KEY='sk-openai-key'" in content
             assert "MSWEA_CONFIGURED='true'" in content
 


### PR DESCRIPTION
## Summary:
Updates the default model from `claude-sonnet-4-20250514` to `claude-sonnet-4-5-20250929` to use the latest  Claude Sonnet 4.5 release.

## Changes:
  - Updated model references in documentation  (quickstart, cookbook, FAQ, usage guides)
  - Updated default model in config files  (swebench.yaml, swebench_roulette.yaml)
  - Updated setup wizard default in config.py
  - Updated test fixtures to use new model
  - Added new model to all_models.txt registry 