### PR TITLE
Add summarize_on_exit option for mini agent

### DIFF
--- a/src/minisweagent/agents/interactive.py
+++ b/src/minisweagent/agents/interactive.py
@@ -30,6 +30,8 @@ class InteractiveAgentConfig(AgentConfig):
     """Never confirm actions that match these regular expressions."""
     confirm_exit: bool = True
     """If the agent wants to finish, do we ask for confirmation from user?"""
+    summarize_on_exit: bool = False
+    """Ask model to summarize changes before exiting."""
 
 
 class InteractiveAgent(DefaultAgent):
@@ -137,10 +139,42 @@ class InteractiveAgent(DefaultAgent):
             return user_input
         return user_input
 
+    def _summarize_changes(self) -> None:
+        """Ask the model to summarize the changes made during the session."""
+        console.print("\n[bold cyan]Generating summary of changes...[/bold cyan]")
+
+        summary_prompt = (
+            "Please provide a brief summary of all the changes you made during this session. "
+            "Include:\n"
+            "- Files modified\n"
+            "- Key changes made\n"
+            "- Any important outcomes or results\n\n"
+            "Keep it concise and to the point."
+        )
+
+        # Add the summary request as a user message
+        self.add_message("user", summary_prompt)
+
+        # Query the model for the summary
+        try:
+            with console.status("Generating summary..."):
+                response = self.model.query(self.messages)
+                summary = response.get("content", str(response))
+
+            console.print("\n[bold green]Summary of changes:[/bold green]")
+            console.print(summary)
+            console.print()
+        except Exception as e:
+            console.print(f"[bold red]Error generating summary: {e}[/bold red]")
+
     def has_finished(self, output: dict[str, str]):
         try:
             return super().has_finished(output)
         except Submitted as e:
+            # Generate summary before confirming exit, if enabled
+            if self.config.summarize_on_exit:
+                self._summarize_changes()
+
             if self.config.confirm_exit:
                 console.print(
                     "[bold green]Agent wants to finish.[/bold green] "

--- a/src/minisweagent/config/mini.yaml
+++ b/src/minisweagent/config/mini.yaml
@@ -145,6 +145,7 @@ agent:
   step_limit: 0.
   cost_limit: 3.
   mode: confirm
+  # summarize_on_exit: false  # Set to true to ask the model to summarize changes before exiting
 environment:
   env:
     PAGER: cat


### PR DESCRIPTION
##Summary

Adds optional summarize_on_exit config to mini agent.
 
When enabled, the model generates a summary of changes before the exit prompt.

  **Changes:**
  - Added `summarize_on_exit` field to `InteractiveAgentConfig` (default:  false)
  - Implemented `_summarize_changes()` method that queries the model for a  summary
  - Summary displays before the exit confirmation prompt
  - Added config example in `mini.yaml` (commented out by default)

  **Usage:**
 Set `summarize_on_exit: true` in any config that uses `InteractiveAgent` (mini.yaml, github_issue.yaml, etc.) 

#293