### PR TITLE
Fix: --cost-limit flag doesn't work with 0 value due to Python falsy check

### DIFF
--- a/src/minisweagent/run/mini.py
+++ b/src/minisweagent/run/mini.py
@@ -77,7 +77,7 @@ def main(
 
     if yolo:
         config.setdefault("agent", {})["mode"] = "yolo"
-    if cost_limit:
+    if cost_limit is not None:
         config.setdefault("agent", {})["cost_limit"] = cost_limit
     if exit_immediately:
         config.setdefault("agent", {})["confirm_exit"] = False


### PR DESCRIPTION
  ## Summary 
Fixes a bug where `--cost-limit 0` was ignored due to Python's falsy value check.
  The `--cost-limit` flag help text states "Set to 0 to disable", but passing `0` would not work because the check `if cost_limit:` evaluates to `False`  when `cost_limit=0` (since `0` is a falsy value in Python).

  ```python
  # (buggy):
  if cost_limit:  # False when cost_limit=0
      config.setdefault("agent", {})["cost_limit"] = cost_limit
```

  ## Fixed:
Changed the check to explicitly test for None.
```python
  if cost_limit is not None:  # True when cost_limit=0
      config.setdefault("agent", {})["cost_limit"] = cost_limit
```

**Works correctly to disable the cost limit**
 ``` python
 python -m minisweagent.run.mini \
    -t "Your task" \
    --cost-limit 0 \
    -y
```
## Testing

  - Manual testing confirms --cost-limit 0 now applies correctly.
  - None (no flag) uses config default as it was.