### PR TITLE
Fix model name argument in DefaultAgent initialization in cookbook

### DIFF
--- a/docs/advanced/cookbook.md
+++ b/docs/advanced/cookbook.md
@@ -41,7 +41,7 @@ You can override the default entry point by setting the `MSWEA_DEFAULT_RUN` envi
     model_name = "anthropic/claude-sonnet-4-5-20250929"
 
     agent = DefaultAgent(
-        get_model(model_name=model_name),
+        get_model(input_model_name=model_name),
         LocalEnvironment(),
     )
     agent.run(task)
@@ -113,7 +113,7 @@ You can override the default entry point by setting the `MSWEA_DEFAULT_RUN` envi
     from minisweagent.environments.local import LocalEnvironment
 
     agent = DefaultAgent(
-        get_model(model_name=model_name),
+        get_model(input_model_name=model_name),
         LocalEnvironment(),
     )
     ```


### PR DESCRIPTION
`get_model` method uses `input_model_name` as argument but current doc uses `model_name` instead.

Ref: https://mini-swe-agent.com/1.0/reference/models/utils/#minisweagent.models.get_model

<!--
Thanks for contributing a pull request, we appreciate you!

If this PR fixes an issue, please reference it, e.g., 'Fixes #1234'.

You can delete this comment.
-->
