### PR TITLE
docs: complete API reference documentation

### DIFF
--- a/docs/reference/models/requesty.md
+++ b/docs/reference/models/requesty.md
@@ -1,0 +1,15 @@
+# Requesty Model
+
+!!! note "Requesty Model class"
+
+    - [Read on GitHub](https://github.com/swe-agent/mini-swe-agent/blob/main/src/minisweagent/models/requesty_model.py)
+
+    ??? note "Full source code"
+
+        ```python
+        --8<-- "src/minisweagent/models/requesty_model.py"
+        ```
+
+::: minisweagent.models.requesty_model
+
+{% include-markdown "../../_footer.md" %}

--- a/docs/reference/run/config.md
+++ b/docs/reference/run/config.md
@@ -1,0 +1,17 @@
+# Config
+
+!!! note "Global Config Manager"
+
+    - [Read on GitHub](https://github.com/swe-agent/mini-swe-agent/blob/main/src/minisweagent/run/extra/config.py)
+
+    ??? note "Full source code"
+
+        ```python
+        --8<-- "src/minisweagent/run/extra/config.py"
+        ```
+
+Utility to manage the global config file via `mini-extra config`.
+
+::: minisweagent.run.extra.config
+
+{% include-markdown "../../_footer.md" %}

--- a/docs/reference/run/inspector.md
+++ b/docs/reference/run/inspector.md
@@ -1,0 +1,15 @@
+# Inspector
+
+!!! note "Trajectory Inspector"
+
+    - [Read on GitHub](https://github.com/swe-agent/mini-swe-agent/blob/main/src/minisweagent/run/inspector.py)
+
+    ??? note "Full source code"
+
+        ```python
+        --8<-- "src/minisweagent/run/inspector.py"
+        ```
+
+::: minisweagent.run.inspector
+
+{% include-markdown "../../_footer.md" %}

--- a/docs/reference/run/mini_extra.md
+++ b/docs/reference/run/mini_extra.md
@@ -1,0 +1,17 @@
+# Mini Extra
+
+!!! note "Mini Extra CLI"
+
+    - [Read on GitHub](https://github.com/swe-agent/mini-swe-agent/blob/main/src/minisweagent/run/mini_extra.py)
+
+    ??? note "Full source code"
+
+        ```python
+        --8<-- "src/minisweagent/run/mini_extra.py"
+        ```
+
+Central entry point for all extra commands from mini-swe-agent.
+
+::: minisweagent.run.mini_extra
+
+{% include-markdown "../../_footer.md" %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,6 +86,7 @@ nav:
       - "LitellmResponseAPIModel": "reference/models/litellm_response.md"
       - "AnthropicModel": "reference/models/anthropic.md"
       - "OpenRouterModel": "reference/models/openrouter.md"
+      - "RequestyModel": "reference/models/requesty.md"
       - "DeterministicModel": "reference/models/test_models.md"
       - "Extra Models": "reference/models/extra.md"
       - "Model Utilities": "reference/models/utils.md"
@@ -98,6 +99,9 @@ nav:
     - Run Scripts:
       - "Hello World": "reference/run/hello_world.md"
       - "mini": "reference/run/mini.md"
+      - "mini-extra": "reference/run/mini_extra.md"
+      - "Config": "reference/run/config.md"
+      - "Inspector": "reference/run/inspector.md"
       - "GitHub Issue": "reference/run/github_issue.md"
       - "SWE-bench (batch)": "reference/run/swebench.md"
       - "SWE-bench (single)": "reference/run/swebench_single.md"


### PR DESCRIPTION
## Summary
  Add missing API reference pages for modules that were not yet documented:

  - **RequestyModel**: New model provider for Requesty router
  - **Inspector**: Trajectory viewer CLI tool
  - **mini-extra**: Central entry point for extra commands
  - **Config**: Global configuration manager

  ## Changes
  - Created 4 new documentation pages in `docs/reference/`
  - Updated `mkdocs.yml` navigation

 Closes #406