### PR TITLE
Fix: Explicitly setting model name for litellm cost calc

### DIFF
--- a/src/minisweagent/models/litellm_model.py
+++ b/src/minisweagent/models/litellm_model.py
@@ -70,7 +70,7 @@ class LitellmModel:
             messages = set_cache_control(messages, mode=self.config.set_cache_control)
         response = self._query(messages, **kwargs)
         try:
-            cost = litellm.cost_calculator.completion_cost(response)
+            cost = litellm.cost_calculator.completion_cost(response, model=self.config.model_name)
             if cost <= 0.0:
                 raise ValueError(f"Cost must be > 0.0, got {cost}")
         except Exception as e:

--- a/src/minisweagent/models/litellm_response_api_model.py
+++ b/src/minisweagent/models/litellm_response_api_model.py
@@ -62,7 +62,7 @@ class LitellmResponseAPIModel(LitellmModel):
         print(response)
         text = coerce_responses_text(response)
         try:
-            cost = litellm.cost_calculator.completion_cost(response)
+            cost = litellm.cost_calculator.completion_cost(response, model=self.config.model_name)
         except Exception as e:
             logger.critical(
                 f"Error calculating cost for model {self.config.model_name}: {e}. "

--- a/src/minisweagent/models/portkey_response_api_model.py
+++ b/src/minisweagent/models/portkey_response_api_model.py
@@ -52,7 +52,7 @@ class PortkeyResponseAPIModel(PortkeyModel):
         response = self._query(messages, **kwargs)
         text = coerce_responses_text(response)
         try:
-            cost = litellm.cost_calculator.completion_cost(response)
+            cost = litellm.cost_calculator.completion_cost(response, model=self.config.model_name)
             assert cost > 0.0, f"Cost is not positive: {cost}"
         except Exception as e:
             if self.config.cost_tracking != "ignore_errors":


### PR DESCRIPTION
This might sometimes avoid cryptic error messages about missing
providers
