### PR TITLE
Fix: Avoid passing extra message information to model

### DIFF
--- a/src/minisweagent/models/litellm_model.py
+++ b/src/minisweagent/models/litellm_model.py
@@ -68,7 +68,7 @@ class LitellmModel:
     def query(self, messages: list[dict[str, str]], **kwargs) -> dict:
         if self.config.set_cache_control:
             messages = set_cache_control(messages, mode=self.config.set_cache_control)
-        response = self._query(messages, **kwargs)
+        response = self._query([{"role": msg["role"], "content": msg["content"]} for msg in messages], **kwargs)
         try:
             cost = litellm.cost_calculator.completion_cost(response, model=self.config.model_name)
             if cost <= 0.0:

--- a/src/minisweagent/models/openrouter_model.py
+++ b/src/minisweagent/models/openrouter_model.py
@@ -97,7 +97,7 @@ class OpenRouterModel:
     def query(self, messages: list[dict[str, str]], **kwargs) -> dict:
         if self.config.set_cache_control:
             messages = set_cache_control(messages, mode=self.config.set_cache_control)
-        response = self._query(messages, **kwargs)
+        response = self._query([{"role": msg["role"], "content": msg["content"]} for msg in messages], **kwargs)
 
         usage = response.get("usage", {})
         cost = usage.get("cost", 0.0)

--- a/src/minisweagent/models/portkey_model.py
+++ b/src/minisweagent/models/portkey_model.py
@@ -90,7 +90,7 @@ class PortkeyModel:
     def query(self, messages: list[dict[str, str]], **kwargs) -> dict:
         if self.config.set_cache_control:
             messages = set_cache_control(messages, mode=self.config.set_cache_control)
-        response = self._query(messages, **kwargs)
+        response = self._query([{"role": msg["role"], "content": msg["content"]} for msg in messages], **kwargs)
         cost = self._calculate_cost(response)
         self.n_calls += 1
         self.cost += cost

--- a/src/minisweagent/models/requesty_model.py
+++ b/src/minisweagent/models/requesty_model.py
@@ -91,7 +91,7 @@ class RequestyModel:
             raise RequestyAPIError(f"Request failed: {e}") from e
 
     def query(self, messages: list[dict[str, str]], **kwargs) -> dict:
-        response = self._query(messages, **kwargs)
+        response = self._query([{"role": msg["role"], "content": msg["content"]} for msg in messages], **kwargs)
 
         # Extract cost from usage information
         usage = response.get("usage", {})


### PR DESCRIPTION
This avoids errors about allowed keys from mistral, for example
(because of the timestamp key)
