### PR TITLE
chore: drop support for MSWEA_MODEL_API_KEY

### DIFF
--- a/docs/advanced/global_configuration.md
+++ b/docs/advanced/global_configuration.md
@@ -30,7 +30,7 @@ or to update specific settings:
 mini-extra config set KEY VALUE
 # e.g.,
 mini-extra config set MSWEA_MODEL_NAME "anthropic/claude-sonnet-4-5-20250929"
-mini-extra config set MSWEA_MODEL_API_KEY "sk-..."
+mini-extra config set ANTHROPIC_API_KEY "sk-..."
 ```
 
 or to unset a key:
@@ -38,7 +38,7 @@ or to unset a key:
 ```bash
 mini-extra config unset KEY
 # e.g.,
-mini-extra config unset MSWEA_MODEL_API_KEY
+mini-extra config unset ANTHROPIC_API_KEY
 ```
 
 You can also edit the `.env` file directly and we provide a helper function for that:
@@ -65,10 +65,6 @@ setx KEY "value"
 # Default model name
 # (default: not set)
 MSWEA_MODEL_NAME="anthropic/claude-sonnet-4-5-20250929"
-
-# Default API key
-# (default: not set)
-MSWEA_MODEL_API_KEY="sk-..."
 ```
 
 To ignore errors from cost tracking checks (for example for free models), set:

--- a/docs/models/quickstart.md
+++ b/docs/models/quickstart.md
@@ -14,7 +14,6 @@ There are several ways to set your API keys:
 * **Recommended**: Run our setup script: `mini-extra config setup`. This should also run automatically the first time you run `mini`.
 * Use `mini-extra config set ANTHROPIC_API_KEY <your-api-key>` to put the key in the `mini` [config file](../advanced/global_configuration.md).
 * Export your key as an environment variable: `export ANTHROPIC_API_KEY=<your-api-key>` (this is not persistent if you restart your shell, unless you add it to your shell config, like `~/.bashrc` or `~/.zshrc`).
-* If you only use a single model, you can also set `MSWEA_MODEL_API_KEY` (as environment variable or in the config file). This takes precedence over all other keys.
 * If you run several agents in parallel, see our note about rotating anthropic keys [here](../advanced/global_configuration.md).
 
 ??? note "All the API key names"

--- a/src/minisweagent/models/__init__.py
+++ b/src/minisweagent/models/__init__.py
@@ -52,9 +52,6 @@ def get_model(input_model_name: str | None = None, config: dict | None = None) -
 
     model_class = get_model_class(resolved_model_name, config.pop("model_class", ""))
 
-    if (from_env := os.getenv("MSWEA_MODEL_API_KEY")) and not str(type(model_class)).endswith("DeterministicModel"):
-        config.setdefault("model_kwargs", {})["api_key"] = from_env
-
     if (
         any(s in resolved_model_name.lower() for s in ["anthropic", "sonnet", "opus", "claude"])
         and "set_cache_control" not in config

--- a/tests/models/test_init.py
+++ b/tests/models/test_init.py
@@ -105,15 +105,6 @@ class TestGetModel:
             assert model.config.outputs == ["hello"]
             assert model.config.model_name == "test-model"
 
-    def test_env_var_overrides_config_api_key(self):
-        """Test that MSWEA_MODEL_API_KEY overrides config api_key."""
-        with patch.dict(os.environ, {"MSWEA_MODEL_API_KEY": "env-key"}):
-            config = {"model_kwargs": {"api_key": "config-key"}, "model_class": "litellm"}
-            model = get_model("test-model", config)
-
-            # LitellmModel stores the api_key in model_kwargs
-            assert model.config.model_kwargs["api_key"] == "env-key"
-
     def test_config_api_key_used_when_no_env_var(self):
         """Test that config api_key is used when env var is not set."""
         with patch.dict(os.environ, {}, clear=True):
@@ -122,15 +113,6 @@ class TestGetModel:
 
             # LitellmModel stores the api_key in model_kwargs
             assert model.config.model_kwargs["api_key"] == "config-key"
-
-    def test_env_var_sets_api_key_when_no_config_key(self):
-        """Test that MSWEA_MODEL_API_KEY is used when config has no api_key."""
-        with patch.dict(os.environ, {"MSWEA_MODEL_API_KEY": "env-key"}):
-            config = {"model_class": "litellm"}
-            model = get_model("test-model", config)
-
-            # LitellmModel stores the api_key in model_kwargs
-            assert model.config.model_kwargs["api_key"] == "env-key"
 
     def test_no_api_key_when_none_provided(self):
         """Test that no api_key is set when neither env var nor config provide one."""


### PR DESCRIPTION
Drop support for the `MSWEA_MODEL_API_KEY` environment variable. Users should use provider-specific API keys instead (e.g., `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `OPENROUTER_API_KEY`).

Closes #653 and #543
