### PR TITLE
feat: Add __all__ to Python modules 

### DIFF
--- a/src/minisweagent/agents/default.py
+++ b/src/minisweagent/agents/default.py
@@ -9,6 +9,17 @@ from pydantic import BaseModel
 
 from minisweagent import Environment, Model
 
+__all__ = [
+    "AgentConfig",
+    "NonTerminatingException",
+    "FormatError",
+    "ExecutionTimeoutError",
+    "TerminatingException",
+    "Submitted",
+    "LimitsExceeded",
+    "DefaultAgent",
+]
+
 
 class AgentConfig(BaseModel):
     # Check the config files in minisweagent/config for example settings

--- a/src/minisweagent/agents/interactive.py
+++ b/src/minisweagent/agents/interactive.py
@@ -17,6 +17,11 @@ from rich.rule import Rule
 from minisweagent import global_config_dir
 from minisweagent.agents.default import AgentConfig, DefaultAgent, LimitsExceeded, NonTerminatingException, Submitted
 
+__all__ = [
+    "InteractiveAgentConfig",
+    "InteractiveAgent",
+]
+
 console = Console(highlight=False)
 prompt_session = PromptSession(history=FileHistory(global_config_dir / "interactive_history.txt"))
 

--- a/src/minisweagent/agents/interactive_textual.py
+++ b/src/minisweagent/agents/interactive_textual.py
@@ -25,6 +25,11 @@ from textual.widgets import Footer, Header, Input, Static, TextArea
 
 from minisweagent.agents.default import AgentConfig, DefaultAgent, NonTerminatingException, Submitted
 
+__all__ = [
+    "TextualAgentConfig",
+    "TextualAgent",
+]
+
 
 class TextualAgentConfig(AgentConfig):
     mode: Literal["confirm", "yolo"] = "confirm"

--- a/src/minisweagent/environments/__init__.py
+++ b/src/minisweagent/environments/__init__.py
@@ -5,6 +5,11 @@ import importlib
 
 from minisweagent import Environment
 
+__all__ = [
+    "get_environment_class",
+    "get_environment",
+]
+
 _ENVIRONMENT_MAPPING = {
     "docker": "minisweagent.environments.docker.DockerEnvironment",
     "singularity": "minisweagent.environments.singularity.SingularityEnvironment",

--- a/src/minisweagent/environments/docker.py
+++ b/src/minisweagent/environments/docker.py
@@ -7,6 +7,11 @@ from typing import Any
 
 from pydantic import BaseModel
 
+__all__ = [
+    "DockerEnvironmentConfig",
+    "DockerEnvironment",
+]
+
 
 class DockerEnvironmentConfig(BaseModel):
     image: str

--- a/src/minisweagent/environments/extra/bubblewrap.py
+++ b/src/minisweagent/environments/extra/bubblewrap.py
@@ -22,6 +22,11 @@ from typing import Any
 
 from pydantic import BaseModel
 
+__all__ = [
+    "BubblewrapEnvironmentConfig",
+    "BubblewrapEnvironment",
+]
+
 
 class BubblewrapEnvironmentConfig(BaseModel):
     cwd: str = ""

--- a/src/minisweagent/environments/extra/swerex_docker.py
+++ b/src/minisweagent/environments/extra/swerex_docker.py
@@ -5,6 +5,11 @@ from pydantic import BaseModel
 from swerex.deployment.docker import DockerDeployment
 from swerex.runtime.abstract import Command as RexCommand
 
+__all__ = [
+    "SwerexDockerEnvironmentConfig",
+    "SwerexDockerEnvironment",
+]
+
 
 class SwerexDockerEnvironmentConfig(BaseModel):
     image: str

--- a/src/minisweagent/environments/local.py
+++ b/src/minisweagent/environments/local.py
@@ -5,6 +5,11 @@ from typing import Any
 
 from pydantic import BaseModel
 
+__all__ = [
+    "LocalEnvironmentConfig",
+    "LocalEnvironment",
+]
+
 
 class LocalEnvironmentConfig(BaseModel):
     cwd: str = ""

--- a/src/minisweagent/environments/singularity.py
+++ b/src/minisweagent/environments/singularity.py
@@ -11,6 +11,11 @@ from typing import Any
 
 from pydantic import BaseModel
 
+__all__ = [
+    "SingularityEnvironmentConfig",
+    "SingularityEnvironment",
+]
+
 
 class SingularityEnvironmentConfig(BaseModel):
     image: str

--- a/src/minisweagent/models/__init__.py
+++ b/src/minisweagent/models/__init__.py
@@ -9,6 +9,13 @@ import threading
 
 from minisweagent import Model
 
+__all__ = [
+    "GlobalModelStats",
+    "get_model",
+    "get_model_name",
+    "get_model_class",
+]
+
 
 class GlobalModelStats:
     """Global model statistics tracker with optional limits."""

--- a/src/minisweagent/models/anthropic.py
+++ b/src/minisweagent/models/anthropic.py
@@ -6,6 +6,11 @@ from minisweagent.models.litellm_model import LitellmModel, LitellmModelConfig
 from minisweagent.models.utils.cache_control import set_cache_control
 from minisweagent.models.utils.key_per_thread import get_key_per_thread
 
+__all__ = [
+    "AnthropicModelConfig",
+    "AnthropicModel",
+]
+
 
 class AnthropicModelConfig(LitellmModelConfig):
     set_cache_control: Literal["default_end"] | None = "default_end"

--- a/src/minisweagent/models/extra/roulette.py
+++ b/src/minisweagent/models/extra/roulette.py
@@ -5,6 +5,13 @@ from pydantic import BaseModel
 from minisweagent import Model
 from minisweagent.models import get_model
 
+__all__ = [
+    "RouletteModelConfig",
+    "RouletteModel",
+    "InterleavingModelConfig",
+    "InterleavingModel",
+]
+
 
 class RouletteModelConfig(BaseModel):
     model_kwargs: list[dict]

--- a/src/minisweagent/models/litellm_model.py
+++ b/src/minisweagent/models/litellm_model.py
@@ -18,6 +18,11 @@ from tenacity import (
 from minisweagent.models import GLOBAL_MODEL_STATS
 from minisweagent.models.utils.cache_control import set_cache_control
 
+__all__ = [
+    "LitellmModelConfig",
+    "LitellmModel",
+]
+
 logger = logging.getLogger("litellm_model")
 
 

--- a/src/minisweagent/models/litellm_response_api_model.py
+++ b/src/minisweagent/models/litellm_response_api_model.py
@@ -14,6 +14,11 @@ from minisweagent.models import GLOBAL_MODEL_STATS
 from minisweagent.models.litellm_model import LitellmModel, LitellmModelConfig
 from minisweagent.models.utils.openai_utils import coerce_responses_text
 
+__all__ = [
+    "LitellmResponseAPIModelConfig",
+    "LitellmResponseAPIModel",
+]
+
 logger = logging.getLogger("litellm_response_api_model")
 
 

--- a/src/minisweagent/models/openrouter_model.py
+++ b/src/minisweagent/models/openrouter_model.py
@@ -16,6 +16,14 @@ from tenacity import (
 from minisweagent.models import GLOBAL_MODEL_STATS
 from minisweagent.models.utils.cache_control import set_cache_control
 
+__all__ = [
+    "OpenRouterModelConfig",
+    "OpenRouterModel",
+    "OpenRouterAPIError",
+    "OpenRouterAuthenticationError",
+    "OpenRouterRateLimitError",
+]
+
 logger = logging.getLogger("openrouter_model")
 
 

--- a/src/minisweagent/models/portkey_model.py
+++ b/src/minisweagent/models/portkey_model.py
@@ -26,6 +26,11 @@ except ImportError:
         "The portkey-ai package is required to use PortkeyModel. Please install it with: pip install portkey-ai"
     )
 
+__all__ = [
+    "PortkeyModelConfig",
+    "PortkeyModel",
+]
+
 
 class PortkeyModelConfig(BaseModel):
     model_name: str

--- a/src/minisweagent/models/portkey_response_api_model.py
+++ b/src/minisweagent/models/portkey_response_api_model.py
@@ -15,6 +15,11 @@ from minisweagent.models.portkey_model import PortkeyModel, PortkeyModelConfig
 from minisweagent.models.utils.cache_control import set_cache_control
 from minisweagent.models.utils.openai_utils import coerce_responses_text
 
+__all__ = [
+    "PortkeyResponseAPIModelConfig",
+    "PortkeyResponseAPIModel",
+]
+
 logger = logging.getLogger("portkey_response_api_model")
 
 

--- a/src/minisweagent/models/requesty_model.py
+++ b/src/minisweagent/models/requesty_model.py
@@ -15,6 +15,14 @@ from tenacity import (
 
 from minisweagent.models import GLOBAL_MODEL_STATS
 
+__all__ = [
+    "RequestyModelConfig",
+    "RequestyModel",
+    "RequestyAPIError",
+    "RequestyAuthenticationError",
+    "RequestyRateLimitError",
+]
+
 logger = logging.getLogger("requesty_model")
 
 

--- a/src/minisweagent/models/test_models.py
+++ b/src/minisweagent/models/test_models.py
@@ -6,6 +6,11 @@ from pydantic import BaseModel
 
 from minisweagent.models import GLOBAL_MODEL_STATS
 
+__all__ = [
+    "DeterministicModelConfig",
+    "DeterministicModel",
+]
+
 
 class DeterministicModelConfig(BaseModel):
     outputs: list[str]

--- a/src/minisweagent/models/utils/cache_control.py
+++ b/src/minisweagent/models/utils/cache_control.py
@@ -2,6 +2,10 @@ import copy
 import warnings
 from typing import Literal
 
+__all__ = [
+    "set_cache_control",
+]
+
 
 def _get_content_text(entry: dict) -> str:
     if isinstance(entry["content"], str):

--- a/src/minisweagent/models/utils/key_per_thread.py
+++ b/src/minisweagent/models/utils/key_per_thread.py
@@ -6,6 +6,10 @@ import threading
 import warnings
 from typing import Any
 
+__all__ = [
+    "get_key_per_thread",
+]
+
 _THREADS_THAT_USED_API_KEYS: list[Any] = []
 
 

--- a/src/minisweagent/models/utils/openai_utils.py
+++ b/src/minisweagent/models/utils/openai_utils.py
@@ -3,6 +3,10 @@ from typing import Any
 
 from openai.types.responses.response_output_message import ResponseOutputMessage
 
+__all__ = [
+    "coerce_responses_text",
+]
+
 logger = logging.getLogger("openai_utils")
 
 

--- a/src/minisweagent/run/extra/config.py
+++ b/src/minisweagent/run/extra/config.py
@@ -18,6 +18,14 @@ from typer import Argument, Typer
 
 from minisweagent import global_config_file
 
+__all__ = [
+    "configure_if_first_time",
+    "setup",
+    "set",
+    "unset",
+    "edit",
+]
+
 app = Typer(
     help=__doc__.format(global_config_file=global_config_file),  # type: ignore
     no_args_is_help=True,

--- a/src/minisweagent/run/extra/utils/batch_progress.py
+++ b/src/minisweagent/run/extra/utils/batch_progress.py
@@ -24,6 +24,10 @@ from rich.table import Table
 
 import minisweagent.models
 
+__all__ = [
+    "RunBatchProgressManager",
+]
+
 
 def _shorten_str(s: str, max_len: int, shorten_left=False) -> str:
     if not shorten_left:

--- a/src/minisweagent/run/utils/save.py
+++ b/src/minisweagent/run/utils/save.py
@@ -5,6 +5,10 @@ from typing import Any
 
 from minisweagent import Agent, __version__
 
+__all__ = [
+    "save_traj",
+]
+
 
 def _get_class_name_with_module(obj: Any) -> str:
     """Get the full class name with module path."""


### PR DESCRIPTION
## Summary
- Add `__all__` declarations to 25 Python modules to clarify public API boundaries
- Covers all main importable modules: agents, environments, models, and utilities
- Fixes #666

## Details
- **25 files modified, +139 lines**
- Added explicit `__all__` declarations to:
  - Agent modules (default, interactive, textual)
  - Environment modules (docker, local, singularity, bubblewrap, swerex)
  - Model modules (anthropic, litellm, openrouter, portkey, etc.)
  - Utility and configuration modules