### PR TITLE
chore: add git diff instructions to SWE-bench configs

### DIFF
--- a/src/minisweagent/config/extra/swebench.yaml
+++ b/src/minisweagent/config/extra/swebench.yaml
@@ -141,7 +141,7 @@ agent:
 
     Step 1: Create the patch file
     Run `git diff -- path/to/file1 path/to/file2 > patch.txt` listing only the source files you modified.
-    Do NOT commit your changes. NEVER use `diff -u` or backup files.
+    Do NOT commit your changes.
 
     <IMPORTANT>
     The patch must only contain changes to the specific source files you modified to fix the issue.

--- a/src/minisweagent/config/extra/swebench_toolcall.yaml
+++ b/src/minisweagent/config/extra/swebench_toolcall.yaml
@@ -79,7 +79,7 @@ agent:
 
     Step 1: Create the patch file
     Run `git diff -- path/to/file1 path/to/file2 > patch.txt` listing only the source files you modified.
-    Do NOT commit your changes. NEVER use `diff -u` or backup files.
+    Do NOT commit your changes.
 
     <IMPORTANT>
     The patch must only contain changes to the specific source files you modified to fix the issue.

--- a/src/minisweagent/config/extra/swebench_xml.yaml
+++ b/src/minisweagent/config/extra/swebench_xml.yaml
@@ -127,7 +127,7 @@ agent:
 
     Step 1: Create the patch file
     Run `git diff -- path/to/file1 path/to/file2 > patch.txt` listing only the source files you modified.
-    Do NOT commit your changes. NEVER use `diff -u` or backup files.
+    Do NOT commit your changes.
 
     <IMPORTANT>
     The patch must only contain changes to the specific source files you modified to fix the issue.


### PR DESCRIPTION
Add explicit git diff command format with file paths to patch creation instructions