### PR TITLE
Fix thinking block ordering in API messages

### DIFF
--- a/src/minisweagent/models/litellm_model.py
+++ b/src/minisweagent/models/litellm_model.py
@@ -26,6 +26,42 @@ from minisweagent.models.utils.openai_multimodal import expand_multimodal_conten
 logger = logging.getLogger("litellm_model")
 
 
+def _is_thinking_block(block) -> bool:
+    """Check if a content block is a thinking-type block."""
+    if not isinstance(block, dict):
+        return False
+    block_type = block.get("type")
+    # Handle both "thinking" and "redacted_thinking" block types
+    return block_type in ("thinking", "redacted_thinking")
+
+
+def _prepare_messages_for_api(messages: list[dict]) -> list[dict]:
+    """Prepare messages for the API.
+
+    - Strips the 'extra' key from messages (internal metadata not sent to API)
+    - Reorders thinking blocks so they are not the final block in assistant messages
+      (Anthropic API requirement)
+    """
+    result = []
+    for msg in messages:
+        msg_copy = {k: v for k, v in msg.items() if k != "extra"}
+        # Only process assistant messages with list content
+        if msg_copy.get("role") == "assistant" and isinstance(msg_copy.get("content"), list):
+            content = msg_copy["content"]
+            # Check if any thinking blocks exist
+            thinking_blocks = [b for b in content if _is_thinking_block(b)]
+            if thinking_blocks:
+                other_blocks = [b for b in content if not _is_thinking_block(b)]
+                if other_blocks:
+                    # Reorder: thinking blocks first, then other blocks
+                    msg_copy["content"] = thinking_blocks + other_blocks
+                else:
+                    # Only thinking blocks - add empty text block
+                    msg_copy["content"] = thinking_blocks + [{"type": "text", "text": ""}]
+        result.append(msg_copy)
+    return result
+
+
 class LitellmModelConfig(BaseModel):
     model_name: str
     model_kwargs: dict[str, Any] = {}
@@ -84,7 +120,7 @@ class LitellmModel:
     def query(self, messages: list[dict[str, str]], **kwargs) -> dict:
         if self.config.set_cache_control:  # anthropic only
             messages = set_cache_control(messages, mode=self.config.set_cache_control)
-        response = self._query([{k: v for k, v in msg.items() if k != "extra"} for msg in messages], **kwargs)
+        response = self._query(_prepare_messages_for_api(messages), **kwargs)
         cost_output = self._calculate_cost(response)
         GLOBAL_MODEL_STATS.add(cost_output["cost"])
         message = response.choices[0].message.model_dump()


### PR DESCRIPTION
Add helper functions to reorder thinking blocks so they're not the final block in assistant messages, which is required by the Anthropic API. Handles both "thinking" and "redacted_thinking" block types.

<!--
Thanks for contributing a pull request, we appreciate you!

If this PR fixes an issue, please reference it, e.g., 'Fixes #1234'.

You can delete this comment.
-->
