### PR TITLE
fix: handle missing command arg in tool calls

### DIFF
--- a/src/minisweagent/models/litellm_toolcall_model.py
+++ b/src/minisweagent/models/litellm_toolcall_model.py
@@ -47,12 +47,14 @@ class LitellmToolcallModel(LitellmModel):
             except Exception as e:
                 error_msg = f"Error parsing tool call arguments: {e}. "
             if tool_call.function.name != "bash":
-                error_msg += f"Unknown tool '{tool_call.function.name}'"
+                error_msg += f"Unknown tool '{tool_call.function.name}'. "
+            if "command" not in args:
+                error_msg += "Missing 'command' argument in bash tool call."
             if error_msg:
                 raise FormatError(
                     {
                         "role": "user",
-                        "content": error_msg,
+                        "content": error_msg.strip(),
                         "extra": {
                             "interrupt_type": "FormatError",
                         },


### PR DESCRIPTION
Add validation for the 'command' key in tool call arguments before accessing it. Previously, if the model called the bash tool with arguments missing the 'command' key, it would crash with a KeyError instead of raising a FormatError that could be handled gracefully.

<!--
Thanks for contributing a pull request, we appreciate you!

If this PR fixes an issue, please reference it, e.g., 'Fixes #1234'.

You can delete this comment.
-->
