### PR TITLE
Move datasets from dev to dependencies; otherwise executing 'mini-extra swebench --help' will result in an error.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dependencies = [
     "platformdirs",
     "textual",
     "prompt_toolkit",
+    "datasets",
     "openai != 1.100.0,!=1.100.1",  # https://github.com/SWE-agent/mini-swe-agent/issues/446
 ]
 
@@ -59,7 +60,6 @@ modal = [
 ]
 
 dev = [
-    "datasets",
     "pytest",
     "pytest-cov",
     "pytest-asyncio",


### PR DESCRIPTION
Move datasets from dev to dependencies; otherwise executing
`$ mini-extra swebench --help`
will result in an error.

```
/run/extra/swebench.py", line 17, in <module>
    from datasets import load_dataset
ModuleNotFoundError: No module named 'datasets'
```
<!--
Thanks for contributing a pull request, we appreciate you!

If this PR fixes an issue, please reference it, e.g., 'Fixes #711 '.

You can delete this comment.
-->
