### PR TITLE
Fix: Retry on transient API errors (500, etc.)

### DIFF
--- a/src/minisweagent/models/litellm_model.py
+++ b/src/minisweagent/models/litellm_model.py
@@ -51,7 +51,6 @@ class LitellmModel:
         litellm.exceptions.NotFoundError,
         litellm.exceptions.PermissionDeniedError,
         litellm.exceptions.ContextWindowExceededError,
-        litellm.exceptions.APIError,
         litellm.exceptions.AuthenticationError,
         KeyboardInterrupt,
     ]


### PR DESCRIPTION
Remove APIError from abort_exceptions to enable retries on transient server errors like 500 Internal Server Error. Previously these errors would abort immediately instead of being retried with exponential backoff.
