### PR TITLE
Enable parallel tool calls and use plain text observation template

### DIFF
--- a/src/minisweagent/config/benchmarks/swebench.yaml
+++ b/src/minisweagent/config/benchmarks/swebench.yaml
@@ -125,16 +125,33 @@ environment:
 
 model:
   observation_template: |
-    {%- if output.exception_info %}Exception: {{ output.exception_info }}
+    {% if output.exception_info -%}
+    <exception>{{output.exception_info}}</exception>
     {% endif -%}
-    {%- if output.output | length < 10000 -%}
-    {{ output.output }}
+    <returncode>{{output.returncode}}</returncode>
+    {% if output.output | length < 10000 -%}
+    <output>
+    {{ output.output -}}
+    </output>
     {%- else -%}
+    <warning>
+    The output of your last command was too long.
+    Please try a different command that produces less output.
+    If you're looking at a file you can try use head, tail or sed to view a smaller number of lines selectively.
+    If you're using grep or find and it produced too much output, you can use a more selective search pattern.
+    If you really need to see something from the full command's output, you can redirect output to a file and then search in that file.
+    </warning>
+    {%- set elided_chars = output.output | length - 10000 -%}
+    <output_head>
     {{ output.output[:5000] }}
-    ... [{{ output.output | length - 10000 }} characters elided] ...
+    </output_head>
+    <elided_chars>
+    {{ elided_chars }} characters elided
+    </elided_chars>
+    <output_tail>
     {{ output.output[-5000:] }}
+    </output_tail>
     {%- endif -%}
-    [exit code {{ output.returncode }}]
   format_error_template: |
     Tool call error. Every response needs to use the 'bash' tool at least once to execute commands.
 


### PR DESCRIPTION
- Allow multiple bash tool calls per response in the prompt
- Update example to show 3 concurrent tool calls
- Add parallel_tool_calls: true to model_kwargs
- Switch observation template from JSON (tojson) to plain text, reducing tool response size by ~32% per response

<!--
Thanks for contributing a pull request, we appreciate you!

If this PR fixes an issue, please reference it, e.g., 'Fixes #1234'.

You can delete this comment.
-->
