### PR TITLE
Make trajectory serialization JSON-safe

### DIFF
--- a/src/minisweagent/agents/default.py
+++ b/src/minisweagent/agents/default.py
@@ -12,7 +12,7 @@ from pydantic import BaseModel
 
 from minisweagent import Environment, Model, __version__
 from minisweagent.exceptions import InterruptAgentFlow, LimitsExceeded
-from minisweagent.utils.serialize import recursive_merge
+from minisweagent.utils.serialize import recursive_merge, to_jsonable
 
 
 class AgentConfig(BaseModel):
@@ -151,5 +151,5 @@ class DefaultAgent:
         data = self.serialize(*extra_dicts)
         if path:
             path.parent.mkdir(parents=True, exist_ok=True)
-            path.write_text(json.dumps(data, indent=2))
+            path.write_text(json.dumps(to_jsonable(data), indent=2))
         return data

--- a/src/minisweagent/models/litellm_model.py
+++ b/src/minisweagent/models/litellm_model.py
@@ -9,13 +9,13 @@ from typing import Any, Literal
 import litellm
 from pydantic import BaseModel
 
+from minisweagent.exceptions import FormatError
 from minisweagent.models import GLOBAL_MODEL_STATS
 from minisweagent.models.utils.actions_toolcall import (
     BASH_TOOL,
     format_toolcall_observation_messages,
     parse_toolcall_actions,
 )
-from minisweagent.exceptions import FormatError
 from minisweagent.models.utils.anthropic_utils import _reorder_anthropic_thinking_blocks
 from minisweagent.models.utils.cache_control import set_cache_control
 from minisweagent.models.utils.openai_multimodal import expand_multimodal_content

--- a/src/minisweagent/models/litellm_model.py
+++ b/src/minisweagent/models/litellm_model.py
@@ -15,6 +15,7 @@ from minisweagent.models.utils.actions_toolcall import (
     format_toolcall_observation_messages,
     parse_toolcall_actions,
 )
+from minisweagent.exceptions import FormatError
 from minisweagent.models.utils.anthropic_utils import _reorder_anthropic_thinking_blocks
 from minisweagent.models.utils.cache_control import set_cache_control
 from minisweagent.models.utils.openai_multimodal import expand_multimodal_content
@@ -84,8 +85,24 @@ class LitellmModel:
         cost_output = self._calculate_cost(response)
         GLOBAL_MODEL_STATS.add(cost_output["cost"])
         message = response.choices[0].message.model_dump()
+        try:
+            actions = self._parse_actions(response)
+        except FormatError as e:
+            # Preserve raw assistant response for debugging (appears in live + final trajectories)
+            debug_message = {
+                "role": "assistant",
+                "content": message.get("content"),
+                "tool_calls": message.get("tool_calls"),
+                "extra": {
+                    "parse_error": True,
+                    "response": response.model_dump(),
+                    **cost_output,
+                    "timestamp": time.time(),
+                },
+            }
+            raise FormatError(debug_message, *e.messages) from e
         message["extra"] = {
-            "actions": self._parse_actions(response),
+            "actions": actions,
             "response": response.model_dump(),
             **cost_output,
             "timestamp": time.time(),

--- a/src/minisweagent/utils/serialize.py
+++ b/src/minisweagent/utils/serialize.py
@@ -24,3 +24,26 @@ def recursive_merge(*dictionaries: dict | None) -> dict:
             else:
                 result[key] = value
     return result
+
+
+def to_jsonable(value: Any) -> Any:
+    """Convert values to something JSON-serializable for logging."""
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, (bytes, bytearray)):
+        return value.decode("utf-8", errors="replace")
+    if isinstance(value, dict):
+        return {str(k): to_jsonable(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple, set)):
+        return [to_jsonable(v) for v in value]
+    if hasattr(value, "model_dump"):
+        try:
+            return to_jsonable(value.model_dump())
+        except Exception:
+            pass
+    if hasattr(value, "__dict__"):
+        try:
+            return to_jsonable(vars(value))
+        except Exception:
+            pass
+    return str(value)


### PR DESCRIPTION
Fixes #727 

# Summary
When a tool‑calling model emits an invalid tool call, the resulting FormatError can include non‑JSON‑serializable data, which causes agent.save() to fail and prevents the trajectory file from being written. This PR makes the error payload JSON‑safe and hardens serialization so trajectories are always persisted.

# Changes

- Wrap FormatError in LitellmModel with a JSON‑safe debug payload that preserves raw assistant content/tool_calls and response metadata.
- Add to_jsonable utility and use it in DefaultAgent.save() to guarantee JSON serialization of trajectories.

# Why
Losing the trajectory on invalid tool calls breaks expected SWE‑bench behavior and makes debugging difficult. This ensures trajectories are written even on malformed tool calls.