### PR TITLE
Add the response message and error to LLM server.

### DIFF
--- a/src/minisweagent/config/benchmarks/swebench.yaml
+++ b/src/minisweagent/config/benchmarks/swebench.yaml
@@ -143,6 +143,7 @@ model:
     }
     {%- endif -%}
   format_error_template: |
+    {{error}}
     Tool call error. Every response needs to use the 'bash' tool at least once to execute commands.
 
     Call the bash tool with your command as the argument:


### PR DESCRIPTION
v2 running the swe bench verified will have a lot of LimitsExceeded error. Checking the traj.json found 
1. the message before the tool call error didn't add to messages and feed back to LLM server
2. the json exception error didn't put in the user message
It will cause the LLM server hard to fix it and keep trying the error response format.
After fixing it, the benchmark score is more reasonable and mini-extra inspect view is more clear. 
<img width="1209" height="476" alt="螢幕擷取畫面 2026-02-06 152126" src="https://github.com/user-attachments/assets/ccd5a04e-ec81-4178-9686-7f188d987fa6" />
