### PR TITLE
litellm default timeout is 600s. Change it to 60s for swebench.

### DIFF
--- a/src/minisweagent/config/benchmarks/swebench.yaml
+++ b/src/minisweagent/config/benchmarks/swebench.yaml
@@ -175,3 +175,4 @@ model:
     drop_params: true
     temperature: 0.0
     parallel_tool_calls: true
+    timeout: 60


### PR DESCRIPTION
Set the litellm timeout to 60s when run the swebench. 
