### PR TITLE
Fix grammar typo and URL casing inconsistencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,8 +83,8 @@ contree = [
 
 [project.urls]
 Documentation = "https://mini-swe-agent.com/latest/"
-Repository = "https://github.com/SWE-agent/mini-SWE-agent"
-"Bug Tracker" = "https://github.com/SWE-agent/mini-SWE-agent/issues"
+Repository = "https://github.com/SWE-agent/mini-swe-agent"
+"Bug Tracker" = "https://github.com/SWE-agent/mini-swe-agent/issues"
 
 [project.scripts]
 mini = "minisweagent.run.mini:app"

--- a/src/minisweagent/config/default.yaml
+++ b/src/minisweagent/config/default.yaml
@@ -22,7 +22,7 @@ agent:
 
     ## Recommended Workflow
 
-    This workflows should be done step-by-step so that you can iterate on your changes and any possible problems.
+    This workflow should be done step-by-step so that you can iterate on your changes and any possible problems.
 
     1. Analyze the codebase by finding and reading relevant files
     2. Create a script to reproduce the issue

--- a/src/minisweagent/config/mini.yaml
+++ b/src/minisweagent/config/mini.yaml
@@ -8,7 +8,7 @@ agent:
 
     ## Recommended Workflow
 
-    This workflows should be done step-by-step so that you can iterate on your changes and any possible problems.
+    This workflow should be done step-by-step so that you can iterate on your changes and any possible problems.
 
     1. Analyze the codebase by finding and reading relevant files
     2. Create a script to reproduce the issue

--- a/src/minisweagent/config/mini_textbased.yaml
+++ b/src/minisweagent/config/mini_textbased.yaml
@@ -22,7 +22,7 @@ agent:
 
     ## Recommended Workflow
 
-    This workflows should be done step-by-step so that you can iterate on your changes and any possible problems.
+    This workflow should be done step-by-step so that you can iterate on your changes and any possible problems.
 
     1. Analyze the codebase by finding and reading relevant files
     2. Create a script to reproduce the issue


### PR DESCRIPTION
## Summary

This PR fixes minor documentation and metadata issues:

### 1. Grammar fix in config files
- Changed "This workflows should be done" → "This workflow should be done"
- Affected files: `mini.yaml`, `mini_textbased.yaml`, `default.yaml`

### 2. URL casing consistency
- Changed repository URLs from `mini-SWE-agent` → `mini-swe-agent`
- Ensures consistency with the actual repository name

## Changes

- `src/minisweagent/config/mini.yaml`: Fix grammar
- `src/minisweagent/config/mini_textbased.yaml`: Fix grammar  
- `src/minisweagent/config/default.yaml`: Fix grammar
- `pyproject.toml`: Fix URL casing in project URLs

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)