### PR TITLE
add run args for podman

### DIFF
--- a/docs/advanced/global_configuration.md
+++ b/docs/advanced/global_configuration.md
@@ -119,7 +119,7 @@ MSWEA_INSPECTOR_STYLE_PATH="/path/to/your/inspector/style.tcss"
 # (default: "singularity")
 MSWEA_SINGULARITY_EXECUTABLE="singularity"
 
-# Path/name to the docker executable
+# Path/name to the container executable such as docker or podman
 # (default: "docker")
 MSWEA_DOCKER_EXECUTABLE="docker"
 

--- a/src/minisweagent/environments/docker.py
+++ b/src/minisweagent/environments/docker.py
@@ -74,6 +74,8 @@ class DockerEnvironment:
     def _start_container(self):
         """Start the Docker container and return the container ID."""
         container_name = f"minisweagent-{uuid.uuid4().hex[:8]}"
+        if self.config.executable == "podman":
+            self.config.run_args = ["--userns=keep-id", "--security-opt", "label=disable"] + self.config.run_args
         cmd = [
             self.config.executable,
             "run",


### PR DESCRIPTION
On servers with a rootless user running podman, this maps the current rootless user’s UID:GID to the same values in the container.
