### PR TITLE
use custom image path

### DIFF
--- a/docs/advanced/global_configuration.md
+++ b/docs/advanced/global_configuration.md
@@ -127,6 +127,22 @@ MSWEA_DOCKER_EXECUTABLE="docker"
 # (default: "bwrap")
 MSWEA_BUBBLEWRAP_EXECUTABLE="bwrap"
 ```
+### Settings for container image
+
+```bash
+# Set the image registry. It accepts both docker.io and any user provided options such as quay.io
+# (default: "docker.io")
+DEFAULT_IMAGE_REGISTRY="docker.io"
+
+# Set the image repository.
+# (default: "swebench/")
+DEFAULT_IMAGE_REPOSITORY_PREFIX="swebench/"
+
+
+# Set the image tag.
+# (default: ":latest")
+DEFAULT_IMAGE_REPOSITORY_TAG=":latest"
+```
 
 ## Default run files
 

--- a/src/minisweagent/run/benchmarks/swebench.py
+++ b/src/minisweagent/run/benchmarks/swebench.py
@@ -5,6 +5,7 @@
 
 import concurrent.futures
 import json
+import os
 import random
 import re
 import threading
@@ -48,6 +49,10 @@ Examples:
 [bold green]-c swebench.yaml -c agent.max_iterations=50[/bold green]
 """
 
+DEFAULT_IMAGE_REGISTRY = os.environ.get("DEFAULT_IMAGE_REGISTRY", "docker.io")
+DEFAULT_IMAGE_REPOSITORY_PREFIX = os.environ.get("DEFAULT_IMAGE_REPOSITORY_PREFIX", "swebench/")
+DEFAULT_IMAGE_REPOSITORY_TAG = os.environ.get("DEFAULT_IMAGE_REPOSITORY_TAG", ":latest")
+
 DEFAULT_CONFIG_FILE = builtin_config_dir / "benchmarks" / "swebench.yaml"
 
 DATASET_MAPPING = {
@@ -86,7 +91,7 @@ def get_swebench_docker_image_name(instance: dict) -> str:
         # Docker doesn't allow double underscore, so we replace them with a magic token
         iid = instance["instance_id"]
         id_docker_compatible = iid.replace("__", "_1776_")
-        image_name = f"docker.io/swebench/sweb.eval.x86_64.{id_docker_compatible}:latest".lower()
+        image_name = f"{DEFAULT_IMAGE_REGISTRY}/{DEFAULT_IMAGE_REPOSITORY_PREFIX}sweb.eval.x86_64.{id_docker_compatible}{DEFAULT_IMAGE_REPOSITORY_TAG}".lower()
     return image_name
 
 


### PR DESCRIPTION
The agent pulls from swebench in dockerhub using the latest image tag. This allows the user to provide their own image registry, repository and tag as an environment variable.

