### PR TITLE
fix/restrict-litellm-version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "requests",
     "jinja2",
     "pydantic >= 2.0",  # v2 required for safe mutable default arguments
-    "litellm >= 1.75.5",  # want to have gpt-5 support
+    "litellm >= 1.75.5, <= 1.82.6", # Litellm 182.8 is compromised
     "tenacity",
     "rich",
     "python-dotenv",


### PR DESCRIPTION
LiteLLM has been compromised in a supply chain attack

https://futuresearch.ai/blog/litellm-pypi-supply-chain-attack/

LiteLLM releases 1.82.7 and 1.82.8 contain malware that exfiltrates your local credentials
