### PR TITLE
Handle tool calls split across chat choices

### DIFF
--- a/src/minisweagent/models/litellm_model.py
+++ b/src/minisweagent/models/litellm_model.py
@@ -13,6 +13,7 @@ from minisweagent.models import GLOBAL_MODEL_STATS
 from minisweagent.models.utils.actions_toolcall import (
     BASH_TOOL,
     format_toolcall_observation_messages,
+    merge_choice_messages,
     parse_toolcall_actions,
 )
 from minisweagent.models.utils.anthropic_utils import _reorder_anthropic_thinking_blocks
@@ -83,7 +84,7 @@ class LitellmModel:
                 response = self._query(self._prepare_messages_for_api(messages), **kwargs)
         cost_output = self._calculate_cost(response)
         GLOBAL_MODEL_STATS.add(cost_output["cost"])
-        message = response.choices[0].message.model_dump()
+        message = merge_choice_messages(response.choices)
         message["extra"] = {
             "actions": self._parse_actions(response),
             "response": response.model_dump(),
@@ -114,7 +115,7 @@ class LitellmModel:
 
     def _parse_actions(self, response) -> list[dict]:
         """Parse tool calls from the response. Raises FormatError if unknown tool."""
-        tool_calls = response.choices[0].message.tool_calls or []
+        tool_calls = merge_choice_messages(response.choices).get("tool_calls") or []
         return parse_toolcall_actions(tool_calls, format_error_template=self.config.format_error_template)
 
     def format_message(self, **kwargs) -> dict:

--- a/src/minisweagent/models/portkey_model.py
+++ b/src/minisweagent/models/portkey_model.py
@@ -12,6 +12,7 @@ from minisweagent.models import GLOBAL_MODEL_STATS
 from minisweagent.models.utils.actions_toolcall import (
     BASH_TOOL,
     format_toolcall_observation_messages,
+    merge_choice_messages,
     parse_toolcall_actions,
 )
 from minisweagent.models.utils.anthropic_utils import _reorder_anthropic_thinking_blocks
@@ -106,7 +107,7 @@ class PortkeyModel:
                 response = self._query(self._prepare_messages_for_api(messages), **kwargs)
         cost_output = self._calculate_cost(response)
         GLOBAL_MODEL_STATS.add(cost_output["cost"])
-        message = response.choices[0].message.model_dump()
+        message = merge_choice_messages(response.choices)
         message["extra"] = {
             "actions": self._parse_actions(response),
             "response": response.model_dump(),
@@ -117,7 +118,7 @@ class PortkeyModel:
 
     def _parse_actions(self, response) -> list[dict]:
         """Parse tool calls from the response. Raises FormatError if unknown tool."""
-        tool_calls = response.choices[0].message.tool_calls or []
+        tool_calls = merge_choice_messages(response.choices).get("tool_calls") or []
         return parse_toolcall_actions(tool_calls, format_error_template=self.config.format_error_template)
 
     def format_message(self, **kwargs) -> dict:

--- a/src/minisweagent/models/utils/actions_toolcall.py
+++ b/src/minisweagent/models/utils/actions_toolcall.py
@@ -2,6 +2,8 @@
 
 import json
 import time
+from collections.abc import Sequence
+from typing import Any
 
 from jinja2 import StrictUndefined, Template
 
@@ -27,6 +29,69 @@ BASH_TOOL = {
 }
 
 
+def _message_to_dict(message: Any) -> dict:
+    if hasattr(message, "model_dump"):
+        return message.model_dump()
+    if isinstance(message, dict):
+        return dict(message)
+    return {
+        "role": getattr(message, "role", "assistant"),
+        "content": getattr(message, "content", None),
+        "tool_calls": getattr(message, "tool_calls", None),
+    }
+
+
+def _tool_call_attr(tool_call: Any, key: str) -> Any:
+    if isinstance(tool_call, dict):
+        return tool_call.get(key)
+    return getattr(tool_call, key, None)
+
+
+def _tool_function_attr(tool_call: Any, key: str) -> Any:
+    function = _tool_call_attr(tool_call, "function")
+    if isinstance(function, dict):
+        return function.get(key)
+    return getattr(function, key, None)
+
+
+def merge_choice_messages(choices: Sequence[Any]) -> dict:
+    """Merge assistant content/tool calls across multiple choices into one message dict."""
+    merged: dict[str, Any] = {}
+    contents: list[Any] = []
+    tool_calls: list[Any] = []
+
+    for choice in choices:
+        choice_message = _message_to_dict(choice.message if hasattr(choice, "message") else choice["message"])
+        if not merged:
+            merged = dict(choice_message)
+        content = choice_message.get("content")
+        if content not in (None, "", []):
+            contents.append(content)
+        if choice_message.get("tool_calls"):
+            tool_calls.extend(choice_message["tool_calls"])
+
+    if not merged:
+        return {"role": "assistant", "content": None, "tool_calls": []}
+
+    if not contents:
+        merged["content"] = None
+    elif len(contents) == 1:
+        merged["content"] = contents[0]
+    elif all(isinstance(content, str) for content in contents):
+        merged["content"] = "\n".join(content for content in contents if content)
+    else:
+        merged_content = []
+        for content in contents:
+            if isinstance(content, list):
+                merged_content.extend(content)
+            else:
+                merged_content.append(content)
+        merged["content"] = merged_content
+
+    merged["tool_calls"] = tool_calls
+    return merged
+
+
 def parse_toolcall_actions(tool_calls: list, *, format_error_template: str) -> list[dict]:
     """Parse tool calls from the response. Raises FormatError if unknown tool or invalid args."""
     if not tool_calls:
@@ -44,12 +109,15 @@ def parse_toolcall_actions(tool_calls: list, *, format_error_template: str) -> l
     for tool_call in tool_calls:
         error_msg = ""
         args = {}
+        tool_name = _tool_function_attr(tool_call, "name")
+        tool_arguments = _tool_function_attr(tool_call, "arguments")
+        tool_call_id = _tool_call_attr(tool_call, "id")
         try:
-            args = json.loads(tool_call.function.arguments)
+            args = json.loads(tool_arguments)
         except Exception as e:
             error_msg = f"Error parsing tool call arguments: {e}."
-        if tool_call.function.name != "bash":
-            error_msg += f"Unknown tool '{tool_call.function.name}'."
+        if tool_name != "bash":
+            error_msg += f"Unknown tool '{tool_name}'."
         if not isinstance(args, dict) or "command" not in args:
             error_msg += "Missing 'command' argument in bash tool call."
         if error_msg:
@@ -62,7 +130,7 @@ def parse_toolcall_actions(tool_calls: list, *, format_error_template: str) -> l
                     "extra": {"interrupt_type": "FormatError"},
                 }
             )
-        actions.append({"command": args["command"], "tool_call_id": tool_call.id})
+        actions.append({"command": args["command"], "tool_call_id": tool_call_id})
     return actions
 
 

--- a/tests/models/test_litellm_model.py
+++ b/tests/models/test_litellm_model.py
@@ -62,6 +62,64 @@ class TestLitellmModel:
         with pytest.raises(FormatError):
             model.query([{"role": "user", "content": "test"}])
 
+    @patch("minisweagent.models.litellm_model.litellm.completion")
+    @patch("minisweagent.models.litellm_model.litellm.cost_calculator.completion_cost")
+    def test_query_merges_tool_calls_across_multiple_choices(self, mock_cost, mock_completion):
+        text_choice = MagicMock()
+        text_choice.message.model_dump.return_value = {
+            "role": "assistant",
+            "content": "Let me start by analyzing the codebase to find the relevant files.",
+            "tool_calls": None,
+        }
+
+        tool_choice = MagicMock()
+        tool_choice.message.model_dump.return_value = {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call_multi",
+                    "function": {"name": "bash", "arguments": '{"command":"find . -name \\"TargetFile.java\\""}'},
+                }
+            ],
+        }
+
+        mock_response = MagicMock()
+        mock_response.choices = [text_choice, tool_choice]
+        mock_response.model_dump.return_value = {}
+        mock_completion.return_value = mock_response
+        mock_cost.return_value = 0.001
+
+        model = LitellmModel(model_name="github_copilot/claude-sonnet-4.6")
+        result = model.query([{"role": "user", "content": "test"}])
+
+        assert result["content"] == "Let me start by analyzing the codebase to find the relevant files."
+        assert result["extra"]["actions"] == [{"command": 'find . -name "TargetFile.java"', "tool_call_id": "call_multi"}]
+
+    def test_parse_actions_accepts_dict_tool_calls(self):
+        model = LitellmModel(model_name="github_copilot/claude-sonnet-4.6")
+        response = MagicMock()
+        response.choices = [
+            MagicMock(
+                message=MagicMock(
+                    model_dump=MagicMock(
+                        return_value={
+                            "role": "assistant",
+                            "content": None,
+                            "tool_calls": [
+                                {
+                                    "id": "call_dict",
+                                    "function": {"name": "bash", "arguments": '{"command":"pwd"}'},
+                                }
+                            ],
+                        }
+                    )
+                )
+            )
+        ]
+
+        assert model._parse_actions(response) == [{"command": "pwd", "tool_call_id": "call_dict"}]
+
     def test_format_observation_messages(self):
         model = LitellmModel(model_name="gpt-4", observation_template="{{ output.output }}")
         message = {"extra": {"actions": [{"command": "echo test", "tool_call_id": "call_1"}]}}

--- a/tests/models/test_litellm_model.py
+++ b/tests/models/test_litellm_model.py
@@ -94,7 +94,9 @@ class TestLitellmModel:
         result = model.query([{"role": "user", "content": "test"}])
 
         assert result["content"] == "Let me start by analyzing the codebase to find the relevant files."
-        assert result["extra"]["actions"] == [{"command": 'find . -name "TargetFile.java"', "tool_call_id": "call_multi"}]
+        assert result["extra"]["actions"] == [
+            {"command": 'find . -name "TargetFile.java"', "tool_call_id": "call_multi"}
+        ]
 
     def test_parse_actions_accepts_dict_tool_calls(self):
         model = LitellmModel(model_name="github_copilot/claude-sonnet-4.6")

--- a/tests/models/test_portkey_model.py
+++ b/tests/models/test_portkey_model.py
@@ -210,7 +210,9 @@ def test_portkey_model_query_merges_tool_calls_across_multiple_choices():
     tool_choice.message.model_dump.return_value = {
         "role": "assistant",
         "content": None,
-        "tool_calls": [{"id": "call_multi", "function": {"name": "bash", "arguments": json.dumps({"command": "ls -la"})}}],
+        "tool_calls": [
+            {"id": "call_multi", "function": {"name": "bash", "arguments": json.dumps({"command": "ls -la"})}}
+        ],
     }
 
     mock_response.choices = [text_choice, tool_choice]

--- a/tests/models/test_portkey_model.py
+++ b/tests/models/test_portkey_model.py
@@ -191,3 +191,41 @@ def test_portkey_model_cost_validation_error():
 
                 assert "Error calculating cost" in str(exc_info.value)
                 assert "MSWEA_COST_TRACKING='ignore_errors'" in str(exc_info.value)
+
+
+def test_portkey_model_query_merges_tool_calls_across_multiple_choices():
+    """Portkey chat completions may also split assistant text and tool calls across choices."""
+    mock_portkey_class = MagicMock()
+    mock_client = MagicMock()
+    mock_response = MagicMock()
+
+    text_choice = MagicMock()
+    text_choice.message.model_dump.return_value = {
+        "role": "assistant",
+        "content": "Let me inspect the repository first.",
+        "tool_calls": None,
+    }
+
+    tool_choice = MagicMock()
+    tool_choice.message.model_dump.return_value = {
+        "role": "assistant",
+        "content": None,
+        "tool_calls": [{"id": "call_multi", "function": {"name": "bash", "arguments": json.dumps({"command": "ls -la"})}}],
+    }
+
+    mock_response.choices = [text_choice, tool_choice]
+    mock_response.model_dump.return_value = {"test": "response"}
+    mock_response.model_copy.return_value = mock_response
+    mock_response.usage = MagicMock(prompt_tokens=10, completion_tokens=5, total_tokens=15)
+
+    mock_client.chat.completions.create.return_value = mock_response
+    mock_portkey_class.return_value = mock_client
+
+    with patch("minisweagent.models.portkey_model.Portkey", mock_portkey_class):
+        with patch.dict(os.environ, {"PORTKEY_API_KEY": "test-key"}):
+            with patch("minisweagent.models.portkey_model.litellm.cost_calculator.completion_cost", return_value=0.01):
+                model = PortkeyModel(model_name="gpt-4o")
+                result = model.query([{"role": "user", "content": "test"}])
+
+    assert result["content"] == "Let me inspect the repository first."
+    assert result["extra"]["actions"] == [{"command": "ls -la", "tool_call_id": "call_multi"}]


### PR DESCRIPTION

Fixes #804

## Summary

This PR fixes tool-call parsing when a chat-completions provider returns assistant text and tool calls in separate `choices` within the same response.

`mini-swe-agent` currently assumes the relevant assistant message is always in `response.choices[0]`. In practice, some provider integrations can return assistant text in one choice and the tool call in another, which causes tool-call parsing to fail even though a valid tool call was returned.

## Changes

- merge assistant content and `tool_calls` across returned chat choices before parsing
- update `LitellmModel` to read merged message/tool-call data instead of only `choices[0]`
- update `PortkeyModel` similarly for consistency
- make tool-call parsing accept both object-style and dict-style tool call entries
- add regression tests for split-choice tool-call responses
- sanitize task-specific fixture names in tests

## Why this helps

This makes tool-call parsing more robust across provider adapters without changing the normal single-choice path.

## Verification

I added regression tests covering:
- assistant text in one choice and tool calls in another
- dict-style tool calls after message normalization

## Reviewer Checklist
- confirm merging across chat choices is acceptable for tool-call models
- confirm object-style and dict-style tool-call parsing both look reasonable
- confirm the added regressions cover the intended response shape without overfitting to one provider

