### PR TITLE
fix: raise ContainerNotRunning when container dies after timeout

### DIFF
--- a/src/minisweagent/environments/docker.py
+++ b/src/minisweagent/environments/docker.py
@@ -8,8 +8,10 @@ from typing import Any
 
 from pydantic import BaseModel
 
-from minisweagent.exceptions import Submitted
+from minisweagent.exceptions import ContainerNotRunning, Submitted
 from minisweagent.utils.serialize import recursive_merge
+
+_CONTAINER_DEAD_MARKERS = ("No such container", "is not running", "no such container")
 
 
 class DockerEnvironmentConfig(BaseModel):
@@ -123,11 +125,31 @@ class DockerEnvironment:
                 stderr=subprocess.STDOUT,
             )
             output = {"output": result.stdout, "returncode": result.returncode, "exception_info": ""}
+            if result.returncode != 0 and any(marker in result.stdout for marker in _CONTAINER_DEAD_MARKERS):
+                raise ContainerNotRunning(
+                    {
+                        "role": "exit",
+                        "content": result.stdout,
+                        "extra": {"exit_status": "ContainerNotRunning", "submission": ""},
+                    }
+                )
+        except ContainerNotRunning:
+            raise
         except Exception as e:
             raw_output = getattr(e, "output", None)
             raw_output = (
                 raw_output.decode("utf-8", errors="replace") if isinstance(raw_output, bytes) else (raw_output or "")
             )
+            if any(marker in str(e) for marker in _CONTAINER_DEAD_MARKERS) or any(
+                marker in raw_output for marker in _CONTAINER_DEAD_MARKERS
+            ):
+                raise ContainerNotRunning(
+                    {
+                        "role": "exit",
+                        "content": raw_output or str(e),
+                        "extra": {"exit_status": "ContainerNotRunning", "submission": ""},
+                    }
+                )
             output = {
                 "output": raw_output,
                 "returncode": -1,

--- a/src/minisweagent/exceptions.py
+++ b/src/minisweagent/exceptions.py
@@ -20,3 +20,7 @@ class UserInterruption(InterruptAgentFlow):
 
 class FormatError(InterruptAgentFlow):
     """Raised when the LM's output is not in the expected format."""
+
+
+class ContainerNotRunning(InterruptAgentFlow):
+    """Raised when the Docker container is no longer running (e.g., after container_timeout expires)."""

--- a/tests/environments/test_docker.py
+++ b/tests/environments/test_docker.py
@@ -1,10 +1,11 @@
 import os
 import subprocess
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from minisweagent.environments.docker import DockerEnvironment, DockerEnvironmentConfig
+from minisweagent.exceptions import ContainerNotRunning
 
 
 def is_docker_available():
@@ -228,3 +229,86 @@ def test_docker_environment_custom_container_timeout(executable):
             )
     finally:
         env.cleanup()
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("executable", environment_params)
+def test_docker_environment_raises_container_not_running_after_timeout(executable):
+    """Test that ContainerNotRunning is raised when executing after container_timeout expires.
+
+    Regression test for https://github.com/SWE-agent/mini-swe-agent/issues/803.
+    Previously, the agent would silently continue making API calls after the container died.
+    """
+    import time
+
+    env = DockerEnvironment(image="python:3.11", executable=executable, container_timeout="3s")
+
+    try:
+        # Container should work initially
+        result = env.execute({"command": "echo 'alive'"})
+        assert result["returncode"] == 0
+
+        # Wait for container to die
+        time.sleep(5)
+
+        # Executing after container death should raise ContainerNotRunning
+        with pytest.raises(ContainerNotRunning) as exc_info:
+            env.execute({"command": "echo 'should fail'"})
+
+        # Verify the exception contains proper exit info
+        assert len(exc_info.value.messages) == 1
+        msg = exc_info.value.messages[0]
+        assert msg["role"] == "exit"
+        assert msg["extra"]["exit_status"] == "ContainerNotRunning"
+        assert msg["extra"]["submission"] == ""
+    finally:
+        env.cleanup()
+
+
+def test_docker_environment_detects_dead_container_from_returncode():
+    """Unit test: ContainerNotRunning raised when subprocess output contains dead-container markers."""
+    mock_result = MagicMock()
+    mock_result.stdout = "Error response from daemon: No such container: abc123\n"
+    mock_result.returncode = 1
+
+    with patch("minisweagent.environments.docker.subprocess") as mock_subprocess:
+        # Mock the container start
+        mock_start = MagicMock()
+        mock_start.stdout = "fake_container_id\n"
+        mock_subprocess.run.side_effect = [mock_start, mock_result]
+        mock_subprocess.PIPE = subprocess.PIPE
+        mock_subprocess.STDOUT = subprocess.STDOUT
+
+        env = DockerEnvironment(image="python:3.11")
+
+        with pytest.raises(ContainerNotRunning) as exc_info:
+            env.execute({"command": "echo test"})
+
+        msg = exc_info.value.messages[0]
+        assert msg["role"] == "exit"
+        assert msg["extra"]["exit_status"] == "ContainerNotRunning"
+
+
+def test_docker_environment_detects_dead_container_from_exception():
+    """Unit test: ContainerNotRunning raised when subprocess raises with dead-container message."""
+    with patch("minisweagent.environments.docker.subprocess") as mock_subprocess:
+        # Mock the container start
+        mock_start = MagicMock()
+        mock_start.stdout = "fake_container_id\n"
+        mock_subprocess.PIPE = subprocess.PIPE
+        mock_subprocess.STDOUT = subprocess.STDOUT
+
+        # First call starts container, second call raises with "is not running"
+        mock_subprocess.run.side_effect = [
+            mock_start,
+            Exception("Error: container fake_container_id is not running"),
+        ]
+
+        env = DockerEnvironment(image="python:3.11")
+
+        with pytest.raises(ContainerNotRunning) as exc_info:
+            env.execute({"command": "echo test"})
+
+        msg = exc_info.value.messages[0]
+        assert msg["role"] == "exit"
+        assert msg["extra"]["exit_status"] == "ContainerNotRunning"


### PR DESCRIPTION
## Summary

- Adds `ContainerNotRunning` exception (subclass of `InterruptAgentFlow`) that terminates the agent loop cleanly when the Docker container dies after `container_timeout` expires
- Detects container-dead markers (`"No such container"`, `"is not running"`) in both subprocess output and exception messages
- Prevents the agent from silently burning API calls after the container is gone

## Problem

When `container_timeout` expires, the container's `sleep` process exits and Docker removes it (`--rm`). Subsequent `docker exec` calls fail, but `execute()` catches the exception and returns it as a normal observation. The model keeps issuing commands until `step_limit` or `cost_limit` is exhausted, wasting API calls and cost.

## Solution

`ContainerNotRunning` extends `InterruptAgentFlow`, so the agent's existing `run()` loop handles it identically to `LimitsExceeded` or `Submitted`: it adds the exit message, saves the trajectory, and stops.

## Test plan

- [x] Unit test: `ContainerNotRunning` raised when subprocess returns dead-container output (non-zero returncode)
- [x] Unit test: `ContainerNotRunning` raised when subprocess raises exception with dead-container message
- [x] Integration test: `ContainerNotRunning` raised after real `container_timeout` expires (requires Docker, marked `@pytest.mark.slow`)
- [x] All existing tests pass

Fixes #803