### PR TITLE
docs: remove model-specific selection recommendations

### DIFF
--- a/docs/models/quickstart.md
+++ b/docs/models/quickstart.md
@@ -88,26 +88,9 @@ There are several ways to set your API keys:
 * You can also set your model in a config file (key `model_name` under `model`).
 * If you want to use local models, please check this [guide](local_models.md).
 
-!!! note "Popular models"
+??? note "List of all supported models"
 
-    Here's a few examples of popular models:
-
-    ```
-    anthropic/claude-sonnet-4-5-20250929
-    openai/gpt-5
-    openai/gpt-5-mini
-    gemini/gemini-2.5-pro
-    deepseek/deepseek-chat
-    ```
-
-    ??? note "List of all supported models"
-
-        Here's a list of all model names supported by `litellm` as of Aug 29th 2025.
-        For even more recent models, check the [`model_prices_and_context_window.json` file from litellm](https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json).
-
-        ```
-        --8<-- "docs/data/all_models.txt"
-        ```
+    Model availability changes quickly. Check the current [`model_prices_and_context_window.json` file from litellm](https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json).
 
 To find the corresponding API key, check the previous section.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -127,8 +127,6 @@
 
     Tip: Please always include the provider in the model name, e.g., `anthropic/claude-...`.
 
-!!! success "Which model to use?"
+!!! success "Model selection"
 
-    We recommend using `anthropic/claude-sonnet-4-5-20250929` for most tasks.
-    For openai models, we recommend using `openai/gpt-5` or `openai/gpt-5-mini`.
-    You can check scores of different models at our [SWE-bench (bash-only)](https://swebench.com) leaderboard.
+    Model availability changes quickly. Check current options in your provider docs and the [SWE-bench (bash-only)](https://swebench.com) leaderboard.


### PR DESCRIPTION
## Summary
- remove the "Which model to use" recommendation block from `docs/quickstart.md`
- remove the hard-coded "Popular models" list from `docs/models/quickstart.md`
- keep model setup guidance provider-agnostic and point readers to current provider/model catalogs

## Test plan
- [x] docs-only change
- [x] verified markdown renders cleanly in diff

Made with [Cursor](https://cursor.com)