### PR TITLE
feat(inspector): display reasoning_content with toggle and hot-reload

### DIFF
--- a/src/minisweagent/config/inspector.tcss
+++ b/src/minisweagent/config/inspector.tcss
@@ -40,3 +40,17 @@ Header {
 Footer {
     dock: bottom;
 }
+
+.reasoning-header {
+    background: $warning;
+    color: $text;
+    padding: 0 1;
+    text-style: italic;
+}
+
+.reasoning-content {
+    height: auto;
+    padding: 1;
+    background: $surface-darken-1;
+    color: $text-muted;
+}

--- a/src/minisweagent/run/utilities/inspector.py
+++ b/src/minisweagent/run/utilities/inspector.py
@@ -55,6 +55,8 @@ class BindingCommandProvider(Provider):
         "previous_trajectory": "Previous trajectory",
         "open_in_jless": "Open the current step in jless",
         "open_in_jless_all": "Open the entire trajectory in jless",
+        "toggle_reasoning": "Toggle reasoning content visibility",
+        "reload": "Reload trajectory file from disk",
         "quit": "Quit the inspector",
     }
 
@@ -87,16 +89,19 @@ class TrajectoryInspector(App):
         Binding("H", "previous_trajectory", "Traj--"),
         Binding("e", "open_in_jless", "Jless"),
         Binding("E", "open_in_jless_all", "Jless (all)"),
+        Binding("r", "toggle_reasoning", "Reasoning"),
+        Binding("R", "reload", "Reload"),
         Binding("q", "quit", "Quit"),
     ]
 
-    def __init__(self, trajectory_files: list[Path]):
+    def __init__(self, trajectory_files: list[Path], show_reasoning: bool = True):
         css_path = os.environ.get(
             "MSWEA_INSPECTOR_STYLE_PATH", str(Path(__file__).parent.parent.parent / "config" / "inspector.tcss")
         )
         self.__class__.CSS = Path(css_path).read_text()
 
         super().__init__()
+        self.show_reasoning = show_reasoning
         self.trajectory_files = trajectory_files
         self._i_trajectory = 0
         self._i_step = 0
@@ -205,6 +210,13 @@ class TrajectoryInspector(App):
             message_container.mount(Static(role.upper(), classes="message-header"))
             clean_str = content_str.replace("\x00", "")
             message_container.mount(Static(Text.from_ansi(clean_str, no_wrap=False), classes="message-content"))
+            reasoning = message.get("reasoning_content")
+            if reasoning and self.show_reasoning:
+                clean_reasoning = reasoning.replace("\x00", "")
+                message_container.mount(Static("REASONING", classes="reasoning-header"))
+                message_container.mount(
+                    Static(Text.from_ansi(clean_reasoning, no_wrap=False), classes="reasoning-content")
+                )
 
         self.title = (
             f"Trajectory {self.i_trajectory + 1}/{self.n_trajectories} - "
@@ -259,6 +271,18 @@ class TrajectoryInspector(App):
         self._open_in_jless(temp_path)
         temp_path.unlink()
 
+    def action_toggle_reasoning(self) -> None:
+        self.show_reasoning = not self.show_reasoning
+        self.update_content()
+
+    def action_reload(self) -> None:
+        """Reload the current trajectory file from disk, preserving step position."""
+        saved_step = self._i_step
+        self._load_current_trajectory()
+        self._i_step = min(saved_step, self.n_steps - 1) if self.n_steps > 0 else 0
+        self.update_content()
+        self.notify("Reloaded")
+
     def action_open_in_jless_all(self) -> None:
         """Open the entire trajectory in jless."""
         if not self.trajectory_files:
@@ -270,6 +294,7 @@ class TrajectoryInspector(App):
 @app.command(help=__doc__)
 def main(
     path: str = typer.Argument(".", help="Directory to search for trajectory files or specific trajectory file"),
+    reasoning: bool = typer.Option(True, "--reasoning/--no-reasoning", help="Show reasoning content"),
 ) -> None:
     path_obj = Path(path)
 
@@ -282,7 +307,7 @@ def main(
     else:
         raise typer.BadParameter(f"Error: Path '{path}' does not exist")
 
-    inspector = TrajectoryInspector(trajectory_files)
+    inspector = TrajectoryInspector(trajectory_files, show_reasoning=reasoning)
     inspector.run()
 
 

--- a/src/minisweagent/run/utilities/inspector.py
+++ b/src/minisweagent/run/utilities/inspector.py
@@ -211,7 +211,7 @@ class TrajectoryInspector(App):
             clean_str = content_str.replace("\x00", "")
             message_container.mount(Static(Text.from_ansi(clean_str, no_wrap=False), classes="message-content"))
             reasoning = message.get("reasoning_content")
-            if reasoning and self.show_reasoning:
+if reasoning and self.show_reasoning and role.lower() == "assistant":
                 clean_reasoning = reasoning.replace("\x00", "")
                 message_container.mount(Static("REASONING", classes="reasoning-header"))
                 message_container.mount(

--- a/src/minisweagent/run/utilities/inspector.py
+++ b/src/minisweagent/run/utilities/inspector.py
@@ -211,7 +211,7 @@ class TrajectoryInspector(App):
             clean_str = content_str.replace("\x00", "")
             message_container.mount(Static(Text.from_ansi(clean_str, no_wrap=False), classes="message-content"))
             reasoning = message.get("reasoning_content")
-if reasoning and self.show_reasoning and role.lower() == "assistant":
+            if reasoning and self.show_reasoning and role.lower() == "assistant":
                 clean_reasoning = reasoning.replace("\x00", "")
                 message_container.mount(Static("REASONING", classes="reasoning-header"))
                 message_container.mount(
@@ -281,7 +281,8 @@ if reasoning and self.show_reasoning and role.lower() == "assistant":
         self._load_current_trajectory()
         self._i_step = min(saved_step, self.n_steps - 1) if self.n_steps > 0 else 0
         self.update_content()
-        self.notify("Reloaded")
+        if self.steps:
+            self.notify("Reloaded")
 
     def action_open_in_jless_all(self) -> None:
         """Open the entire trajectory in jless."""

--- a/tests/run/test_inspector.py
+++ b/tests/run/test_inspector.py
@@ -343,6 +343,8 @@ async def test_trajectory_inspector_css_loading():
     assert ".message-container" in app.CSS
     assert ".message-header" in app.CSS
     assert ".message-content" in app.CSS
+    assert ".reasoning-header" in app.CSS
+    assert ".reasoning-content" in app.CSS
 
 
 @pytest.mark.slow
@@ -367,6 +369,118 @@ def test_trajectory_inspector_binding_labels():
     bindings = {b.action: b.description for b in TrajectoryInspector.BINDINGS}
     assert bindings["scroll_down"] == "↓"
     assert bindings["scroll_up"] == "↑"
+
+
+@patch("minisweagent.run.utilities.inspector.TrajectoryInspector.run")
+def test_main_no_reasoning_flag(mock_run, temp_trajectory_files):
+    """Test that --no-reasoning passes show_reasoning=False to TrajectoryInspector."""
+    valid_file = temp_trajectory_files[0]
+    with patch("minisweagent.run.utilities.inspector.TrajectoryInspector.__init__", return_value=None) as mock_init:
+        try:
+            main(str(valid_file), reasoning=False)
+        except AttributeError:
+            pass  # __init__ mocked, app state incomplete — expected
+        mock_init.assert_called_once_with([valid_file], show_reasoning=False)
+
+
+@pytest.fixture
+def sample_reasoning_trajectory():
+    """Sample trajectory with reasoning_content on an assistant message."""
+    return [
+        {"role": "user", "content": "Think about this."},
+        {"role": "assistant", "content": "My answer.", "reasoning_content": "Let me think..."},
+    ]
+
+
+@pytest.mark.slow
+async def test_trajectory_inspector_reasoning_display(sample_reasoning_trajectory):
+    """Test that reasoning_content is shown/hidden based on show_reasoning flag."""
+    with tempfile.TemporaryDirectory() as tmp:
+        f = Path(tmp) / "r.traj.json"
+        f.write_text(json.dumps(sample_reasoning_trajectory))
+
+        app = TrajectoryInspector([f], show_reasoning=True)
+        async with app.run_test() as pilot:
+            await pilot.pause(0.1)
+            await pilot.press("l")  # step with assistant message
+            await pilot.pause(0.1)
+            content = get_screen_text(app)
+            assert "REASONING" in content
+            assert "Let me think..." in content
+
+        app2 = TrajectoryInspector([f], show_reasoning=False)
+        async with app2.run_test() as pilot:
+            await pilot.pause(0.1)
+            await pilot.press("l")
+            await pilot.pause(0.1)
+            assert "REASONING" not in get_screen_text(app2)
+
+
+@pytest.mark.slow
+async def test_trajectory_inspector_toggle_reasoning(sample_reasoning_trajectory):
+    """Test that pressing r toggles reasoning blocks on and off."""
+    with tempfile.TemporaryDirectory() as tmp:
+        f = Path(tmp) / "r.traj.json"
+        f.write_text(json.dumps(sample_reasoning_trajectory))
+
+        app = TrajectoryInspector([f])
+        async with app.run_test() as pilot:
+            await pilot.pause(0.1)
+            await pilot.press("l")
+            await pilot.pause(0.1)
+            assert "REASONING" in get_screen_text(app)
+
+            await pilot.press("r")  # toggle off
+            assert "REASONING" not in get_screen_text(app)
+
+            await pilot.press("r")  # toggle back on
+            assert "REASONING" in get_screen_text(app)
+
+
+@pytest.mark.slow
+async def test_trajectory_inspector_reload(sample_simple_trajectory):
+    """Test that R reloads the file and preserves step position."""
+    with tempfile.TemporaryDirectory() as tmp:
+        f = Path(tmp) / "t.traj.json"
+        f.write_text(json.dumps(sample_simple_trajectory))
+
+        app = TrajectoryInspector([f])
+        async with app.run_test() as pilot:
+            await pilot.pause(0.1)
+            await pilot.press("l")  # go to step 2
+            assert "Step 2/3" in app.title
+
+            f.write_text(
+                json.dumps(
+                    sample_simple_trajectory
+                    + [
+                        {"role": "user", "content": "extra output"},
+                        {"role": "assistant", "content": "Done."},
+                    ]
+                )
+            )
+            await pilot.press("R")
+            await pilot.pause(0.1)
+            assert "Step 2/4" in app.title
+
+
+@pytest.mark.slow
+async def test_trajectory_inspector_reload_clamps_step(sample_simple_trajectory):
+    """Test that R clamps step to last when the file shrinks."""
+    with tempfile.TemporaryDirectory() as tmp:
+        f = Path(tmp) / "t.traj.json"
+        f.write_text(json.dumps(sample_simple_trajectory))
+
+        app = TrajectoryInspector([f])
+        async with app.run_test() as pilot:
+            await pilot.pause(0.1)
+            await pilot.press("$")  # go to last step (3/3)
+            assert "Step 3/3" in app.title
+
+            f.write_text(json.dumps(sample_simple_trajectory[:2]))
+            await pilot.press("R")
+            await pilot.pause(0.1)
+            assert "Step 1/1" in app.title
 
 
 @pytest.fixture

--- a/tests/run/test_inspector.py
+++ b/tests/run/test_inspector.py
@@ -376,11 +376,9 @@ def test_main_no_reasoning_flag(mock_run, temp_trajectory_files):
     """Test that --no-reasoning passes show_reasoning=False to TrajectoryInspector."""
     valid_file = temp_trajectory_files[0]
     with patch("minisweagent.run.utilities.inspector.TrajectoryInspector.__init__", return_value=None) as mock_init:
-        try:
-            main(str(valid_file), reasoning=False)
-        except AttributeError:
-            pass  # __init__ mocked, app state incomplete — expected
+        main(str(valid_file), reasoning=False)
         mock_init.assert_called_once_with([valid_file], show_reasoning=False)
+        mock_run.assert_called_once()
 
 
 @pytest.fixture


### PR DESCRIPTION
1. Show `reasoning_content` field from assistant messages in the trajectory inspector. The field is already stored in trajectory JSON files but was ignored. Visual reasoning blocks render below the main assistant content with an italic header and darker background. Can be a useful debugging tool to check reasoning output.

2. Additionally, a hot reload button enables user's to “watch” the trajectory output during debugging. This hot-reload updates the file without closing the tool. 

New hotkeys:

| Key | Action |
|--------|--------|
| `r` | Toggle reasoning blocks on/off |
| `R` | Reload trajectory file from disk (preserves current step; clamps if file shrank) |


New CLI flag: --reasoning / --no-reasoning (defaults to reasoning)

Files changed

- src/minisweagent/run/utilities/inspector.py 
- tests/run/test_inspector.py


Note: If there are any changes to the approach or the tests, I'm happy to iterate! I found this functionality very helpful when debugging a project of mine over the last few weeks. :)