### PR TITLE
[fix] preserve explicit zero cost limit

### DIFF
--- a/src/minisweagent/run/benchmarks/swebench_single.py
+++ b/src/minisweagent/run/benchmarks/swebench_single.py
@@ -72,7 +72,7 @@ def main(
         "agent": {
             "agent_class": agent_class or UNSET,
             "mode": "yolo" if yolo else UNSET,
-            "cost_limit": cost_limit or UNSET,
+            "cost_limit": cost_limit if cost_limit is not None else UNSET,
             "confirm_exit": False if exit_immediately else UNSET,
             "output_path": output or UNSET,
         },

--- a/src/minisweagent/run/mini.py
+++ b/src/minisweagent/run/mini.py
@@ -77,7 +77,7 @@ def main(
         "agent": {
             "agent_class": agent_class or UNSET,
             "mode": "yolo" if yolo else UNSET,
-            "cost_limit": cost_limit or UNSET,
+            "cost_limit": cost_limit if cost_limit is not None else UNSET,
             "confirm_exit": False if exit_immediately else UNSET,
             "output_path": output or UNSET,
         },

--- a/tests/run/test_cli_integration.py
+++ b/tests/run/test_cli_integration.py
@@ -268,6 +268,36 @@ def test_confirm_mode_sets_correct_agent_config():
         mock_agent.run.assert_called_once_with("Test confirm task")
 
 
+def test_cost_limit_zero_is_preserved():
+    """Test that an explicit cost_limit=0 is not dropped during config merge."""
+    with (
+        patch("minisweagent.run.mini.configure_if_first_time"),
+        patch("minisweagent.run.mini.get_agent") as mock_get_agent,
+        patch("minisweagent.run.mini.get_model") as mock_get_model,
+        patch("minisweagent.run.mini.get_environment") as mock_get_env,
+        patch("minisweagent.run.mini.get_config_from_spec") as mock_get_config,
+    ):
+        mock_get_model.return_value = Mock()
+        mock_get_env.return_value = Mock()
+        mock_get_config.return_value = {"agent": {"system_template": "test"}, "env": {}, "model": {}}
+        mock_agent = Mock()
+        mock_get_agent.return_value = mock_agent
+
+        main(
+            config_spec=[str(DEFAULT_CONFIG_FILE)],
+            model_name="test-model",
+            task="Test cost limit task",
+            yolo=False,
+            cost_limit=0,
+            output=None,
+            model_class=None,
+            agent_class=None,
+            environment_class=None,
+        )
+
+        assert mock_get_agent.call_args.args[2]["cost_limit"] == 0
+
+
 def test_mini_help():
     """Test that mini --help works correctly."""
     result = subprocess.run(

--- a/tests/run/test_swebench_single.py
+++ b/tests/run/test_swebench_single.py
@@ -1,5 +1,5 @@
 import re
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -20,6 +20,37 @@ def _make_model_from_fixture(text_outputs: list[str], cost_per_call: float = 1.0
         cost_per_call=cost_per_call,
         **kwargs,
     )
+
+
+def test_swebench_single_cost_limit_zero_is_preserved():
+    """Test that an explicit cost_limit=0 is not dropped during config merge."""
+    with (
+        patch("minisweagent.run.benchmarks.swebench_single.load_dataset", return_value=[{"instance_id": "instance"}]),
+        patch("minisweagent.run.benchmarks.swebench_single.get_sb_environment") as mock_get_env,
+        patch("minisweagent.run.benchmarks.swebench_single.get_model") as mock_get_model,
+        patch("minisweagent.run.benchmarks.swebench_single.get_agent") as mock_get_agent,
+        patch("minisweagent.run.benchmarks.swebench_single.get_config_from_spec", return_value={}),
+    ):
+        mock_get_model.return_value = object()
+        mock_get_env.return_value = object()
+        mock_get_agent.return_value = Mock()
+
+        main(
+            subset="_test",
+            split="test",
+            instance_spec="0",
+            model_name="deterministic",
+            config_spec=[str(package_dir / "config" / "benchmarks" / "swebench.yaml")],
+            environment_class="docker",
+            exit_immediately=False,
+            output=None,
+            model_class=None,
+            agent_class=None,
+            yolo=False,
+            cost_limit=0,
+        )
+
+        assert mock_get_agent.call_args.args[2]["cost_limit"] == 0
 
 
 @pytest.mark.slow


### PR DESCRIPTION
## What changed
- preserve an explicit `--cost-limit 0` in `mini` and `swebench-single` instead of treating it as an unset value
- add focused regression coverage for both entrypoints so `cost_limit=0` survives config merging

## Why it changed
- the CLI help says `0` disables the cost limit, but the runners were dropping that value before agent config was built

## User or developer impact
- users can now pass `--cost-limit 0` and reliably disable the per-run cost cap from the CLI
- the new regression tests make future regressions in this config path much harder to reintroduce

## Root cause
- both runners used `cost_limit or UNSET`, and Python treats `0.0` as falsy, so the explicit CLI value was discarded and the config default won instead

## Validation performed
- `uv run pytest tests/run/test_cli_integration.py -k cost_limit_zero_is_preserved`
- `uv run python` isolated verification of the `swebench_single` config path with `datasets` stubbed
- `python -m compileall src/minisweagent/run/mini.py src/minisweagent/run/benchmarks/swebench_single.py tests/run/test_cli_integration.py tests/run/test_swebench_single.py`

## Review focus
- confirm the CLI merge behavior now distinguishes `None` from `0`
- confirm both entrypoints still preserve existing defaults when `--cost-limit` is omitted
- confirm the new tests cover the intended regression without changing unrelated runner behavior
- note that full `tests/run/test_swebench_single.py` collection is still blocked locally because this Python build lacks `_lzma` for `datasets`

Closes #813.
