### PR TITLE
fix: persist full model response in extra dict on FormatError (#784)

### DIFF
--- a/src/minisweagent/models/litellm_model.py
+++ b/src/minisweagent/models/litellm_model.py
@@ -9,6 +9,7 @@ from typing import Any, Literal
 import litellm
 from pydantic import BaseModel
 
+from minisweagent.exceptions import FormatError
 from minisweagent.models import GLOBAL_MODEL_STATS
 from minisweagent.models.utils.actions_toolcall import (
     BASH_TOOL,
@@ -83,9 +84,14 @@ class LitellmModel:
                 response = self._query(self._prepare_messages_for_api(messages), **kwargs)
         cost_output = self._calculate_cost(response)
         GLOBAL_MODEL_STATS.add(cost_output["cost"])
+        try:
+            actions = self._parse_actions(response)
+        except FormatError as e:
+            e.messages[0]["extra"]["response"] = response.model_dump(mode="json")
+            raise
         message = response.choices[0].message.model_dump()
         message["extra"] = {
-            "actions": self._parse_actions(response),
+            "actions": actions,
             "response": response.model_dump(),
             **cost_output,
             "timestamp": time.time(),

--- a/src/minisweagent/models/litellm_model.py
+++ b/src/minisweagent/models/litellm_model.py
@@ -84,13 +84,16 @@ class LitellmModel:
                 response = self._query(self._prepare_messages_for_api(messages), **kwargs)
         cost_output = self._calculate_cost(response)
         GLOBAL_MODEL_STATS.add(cost_output["cost"])
+        # Note: all model.query() implementations must persist the response on FormatError.
         try:
             actions = self._parse_actions(response)
         except FormatError as e:
             try:
                 e.messages[0]["extra"]["response"] = response.model_dump(mode="json")
             except Exception:
-                pass
+                # model_dump failed (e.g. unserializable object); fall back to repr
+                # so the spec contract ("response MUST be persisted") holds unconditionally.
+                e.messages[0]["extra"]["response"] = repr(response)
             raise
         message = response.choices[0].message.model_dump()
         message["extra"] = {

--- a/src/minisweagent/models/litellm_model.py
+++ b/src/minisweagent/models/litellm_model.py
@@ -87,7 +87,10 @@ class LitellmModel:
         try:
             actions = self._parse_actions(response)
         except FormatError as e:
-            e.messages[0]["extra"]["response"] = response.model_dump(mode="json")
+            try:
+                e.messages[0]["extra"]["response"] = response.model_dump(mode="json")
+            except Exception:
+                pass
             raise
         message = response.choices[0].message.model_dump()
         message["extra"] = {

--- a/src/minisweagent/models/litellm_response_model.py
+++ b/src/minisweagent/models/litellm_response_model.py
@@ -4,6 +4,7 @@ from collections.abc import Callable
 
 import litellm
 
+from minisweagent.exceptions import FormatError
 from minisweagent.models import GLOBAL_MODEL_STATS
 from minisweagent.models.litellm_model import LitellmModel, LitellmModelConfig
 from minisweagent.models.utils.actions_toolcall_response import (
@@ -53,9 +54,16 @@ class LitellmResponseModel(LitellmModel):
                 response = self._query(self._prepare_messages_for_api(messages), **kwargs)
         cost_output = self._calculate_cost(response)
         GLOBAL_MODEL_STATS.add(cost_output["cost"])
+        try:
+            actions = self._parse_actions(response)
+        except FormatError as e:
+            e.messages[0]["extra"]["response"] = (
+                response.model_dump(mode="json") if hasattr(response, "model_dump") else dict(response)
+            )
+            raise
         message = response.model_dump() if hasattr(response, "model_dump") else dict(response)
         message["extra"] = {
-            "actions": self._parse_actions(response),
+            "actions": actions,
             **cost_output,
             "timestamp": time.time(),
         }

--- a/src/minisweagent/models/litellm_response_model.py
+++ b/src/minisweagent/models/litellm_response_model.py
@@ -59,9 +59,13 @@ class LitellmResponseModel(LitellmModel):
         except FormatError as e:
             # hasattr guard: litellm.responses() returns a pydantic object, but tests
             # may inject a plain dict; dict(response) is the correct fallback in that case.
-            e.messages[0]["extra"]["response"] = (
-                response.model_dump(mode="json") if hasattr(response, "model_dump") else dict(response)
-            )
+            # Inner try: if serialization itself fails, repr() guarantees the key is always set.
+            try:
+                e.messages[0]["extra"]["response"] = (
+                    response.model_dump(mode="json") if hasattr(response, "model_dump") else dict(response)
+                )
+            except Exception:
+                e.messages[0]["extra"]["response"] = repr(response)
             raise
         message = response.model_dump() if hasattr(response, "model_dump") else dict(response)
         message["extra"] = {

--- a/src/minisweagent/models/litellm_response_model.py
+++ b/src/minisweagent/models/litellm_response_model.py
@@ -57,6 +57,8 @@ class LitellmResponseModel(LitellmModel):
         try:
             actions = self._parse_actions(response)
         except FormatError as e:
+            # hasattr guard: litellm.responses() returns a pydantic object, but tests
+            # may inject a plain dict; dict(response) is the correct fallback in that case.
             e.messages[0]["extra"]["response"] = (
                 response.model_dump(mode="json") if hasattr(response, "model_dump") else dict(response)
             )

--- a/src/minisweagent/models/openrouter_model.py
+++ b/src/minisweagent/models/openrouter_model.py
@@ -103,6 +103,7 @@ class OpenRouterModel:
         try:
             actions = self._parse_actions(response)
         except FormatError as e:
+            # dict(response) is a shallow copy; the original response object is not mutated.
             e.messages[0]["extra"]["response"] = dict(response)
             raise
         message = dict(response["choices"][0]["message"])

--- a/src/minisweagent/models/openrouter_model.py
+++ b/src/minisweagent/models/openrouter_model.py
@@ -103,7 +103,7 @@ class OpenRouterModel:
         try:
             actions = self._parse_actions(response)
         except FormatError as e:
-            e.messages[0]["extra"]["response"] = response
+            e.messages[0]["extra"]["response"] = dict(response)
             raise
         message = dict(response["choices"][0]["message"])
         message["extra"] = {

--- a/src/minisweagent/models/openrouter_model.py
+++ b/src/minisweagent/models/openrouter_model.py
@@ -7,6 +7,7 @@ from typing import Any, Literal
 import requests
 from pydantic import BaseModel
 
+from minisweagent.exceptions import FormatError
 from minisweagent.models import GLOBAL_MODEL_STATS
 from minisweagent.models.utils.actions_toolcall import (
     BASH_TOOL,
@@ -99,9 +100,14 @@ class OpenRouterModel:
                 response = self._query(self._prepare_messages_for_api(messages), **kwargs)
         cost_output = self._calculate_cost(response)
         GLOBAL_MODEL_STATS.add(cost_output["cost"])
+        try:
+            actions = self._parse_actions(response)
+        except FormatError as e:
+            e.messages[0]["extra"]["response"] = response
+            raise
         message = dict(response["choices"][0]["message"])
         message["extra"] = {
-            "actions": self._parse_actions(response),
+            "actions": actions,
             "response": response,
             **cost_output,
             "timestamp": time.time(),

--- a/src/minisweagent/models/openrouter_response_model.py
+++ b/src/minisweagent/models/openrouter_response_model.py
@@ -90,7 +90,7 @@ class OpenRouterResponseModel(OpenRouterModel):
         try:
             actions = self._parse_actions(response)
         except FormatError as e:
-            e.messages[0]["extra"]["response"] = response
+            e.messages[0]["extra"]["response"] = dict(response)
             raise
         message = dict(response)
         message["extra"] = {

--- a/src/minisweagent/models/openrouter_response_model.py
+++ b/src/minisweagent/models/openrouter_response_model.py
@@ -4,6 +4,7 @@ import time
 
 import requests
 
+from minisweagent.exceptions import FormatError
 from minisweagent.models import GLOBAL_MODEL_STATS
 from minisweagent.models.openrouter_model import (
     OpenRouterAPIError,
@@ -86,9 +87,14 @@ class OpenRouterResponseModel(OpenRouterModel):
                 response = self._query(self._prepare_messages_for_api(messages), **kwargs)
         cost_output = self._calculate_cost(response)
         GLOBAL_MODEL_STATS.add(cost_output["cost"])
+        try:
+            actions = self._parse_actions(response)
+        except FormatError as e:
+            e.messages[0]["extra"]["response"] = response
+            raise
         message = dict(response)
         message["extra"] = {
-            "actions": self._parse_actions(response),
+            "actions": actions,
             **cost_output,
             "timestamp": time.time(),
         }

--- a/src/minisweagent/models/portkey_model.py
+++ b/src/minisweagent/models/portkey_model.py
@@ -8,6 +8,7 @@ from typing import Any, Literal
 import litellm
 from pydantic import BaseModel
 
+from minisweagent.exceptions import FormatError
 from minisweagent.models import GLOBAL_MODEL_STATS
 from minisweagent.models.utils.actions_toolcall import (
     BASH_TOOL,
@@ -106,9 +107,14 @@ class PortkeyModel:
                 response = self._query(self._prepare_messages_for_api(messages), **kwargs)
         cost_output = self._calculate_cost(response)
         GLOBAL_MODEL_STATS.add(cost_output["cost"])
+        try:
+            actions = self._parse_actions(response)
+        except FormatError as e:
+            e.messages[0]["extra"]["response"] = response.model_dump(mode="json")
+            raise
         message = response.choices[0].message.model_dump()
         message["extra"] = {
-            "actions": self._parse_actions(response),
+            "actions": actions,
             "response": response.model_dump(),
             **cost_output,
             "timestamp": time.time(),

--- a/src/minisweagent/models/portkey_model.py
+++ b/src/minisweagent/models/portkey_model.py
@@ -110,7 +110,10 @@ class PortkeyModel:
         try:
             actions = self._parse_actions(response)
         except FormatError as e:
-            e.messages[0]["extra"]["response"] = response.model_dump(mode="json")
+            try:
+                e.messages[0]["extra"]["response"] = response.model_dump(mode="json")
+            except Exception:
+                pass
             raise
         message = response.choices[0].message.model_dump()
         message["extra"] = {

--- a/src/minisweagent/models/portkey_model.py
+++ b/src/minisweagent/models/portkey_model.py
@@ -113,7 +113,9 @@ class PortkeyModel:
             try:
                 e.messages[0]["extra"]["response"] = response.model_dump(mode="json")
             except Exception:
-                pass
+                # model_dump failed (e.g. unserializable object); fall back to repr
+                # so the spec contract ("response MUST be persisted") holds unconditionally.
+                e.messages[0]["extra"]["response"] = repr(response)
             raise
         message = response.choices[0].message.model_dump()
         message["extra"] = {

--- a/src/minisweagent/models/portkey_response_model.py
+++ b/src/minisweagent/models/portkey_response_model.py
@@ -101,9 +101,14 @@ class PortkeyResponseAPIModel:
         try:
             actions = self._parse_actions(response)
         except FormatError as e:
-            e.messages[0]["extra"]["response"] = (
-                response.model_dump(mode="json") if hasattr(response, "model_dump") else dict(response)
-            )
+            # hasattr guard: Portkey returns a pydantic object, but tests may inject a plain dict.
+            # Inner try: if serialization itself fails, repr() guarantees the key is always set.
+            try:
+                e.messages[0]["extra"]["response"] = (
+                    response.model_dump(mode="json") if hasattr(response, "model_dump") else dict(response)
+                )
+            except Exception:
+                e.messages[0]["extra"]["response"] = repr(response)
             raise
         message = response.model_dump() if hasattr(response, "model_dump") else dict(response)
         message["extra"] = {

--- a/src/minisweagent/models/portkey_response_model.py
+++ b/src/minisweagent/models/portkey_response_model.py
@@ -8,6 +8,7 @@ from typing import Any, Literal
 import litellm
 from pydantic import BaseModel
 
+from minisweagent.exceptions import FormatError
 from minisweagent.models import GLOBAL_MODEL_STATS
 from minisweagent.models.utils.actions_toolcall_response import (
     BASH_TOOL_RESPONSE_API,
@@ -97,9 +98,16 @@ class PortkeyResponseAPIModel:
                 response = self._query(self._prepare_messages_for_api(messages), **kwargs)
         cost_output = self._calculate_cost(response)
         GLOBAL_MODEL_STATS.add(cost_output["cost"])
+        try:
+            actions = self._parse_actions(response)
+        except FormatError as e:
+            e.messages[0]["extra"]["response"] = (
+                response.model_dump(mode="json") if hasattr(response, "model_dump") else dict(response)
+            )
+            raise
         message = response.model_dump() if hasattr(response, "model_dump") else dict(response)
         message["extra"] = {
-            "actions": self._parse_actions(response),
+            "actions": actions,
             **cost_output,
             "timestamp": time.time(),
         }

--- a/src/minisweagent/models/requesty_model.py
+++ b/src/minisweagent/models/requesty_model.py
@@ -108,7 +108,7 @@ class RequestyModel:
         try:
             actions = self._parse_actions(response)
         except FormatError as e:
-            e.messages[0]["extra"]["response"] = response
+            e.messages[0]["extra"]["response"] = dict(response)
             raise
         message = dict(response["choices"][0]["message"])
         message["extra"] = {

--- a/src/minisweagent/models/requesty_model.py
+++ b/src/minisweagent/models/requesty_model.py
@@ -108,6 +108,7 @@ class RequestyModel:
         try:
             actions = self._parse_actions(response)
         except FormatError as e:
+            # dict(response) is a shallow copy; the original response object is not mutated.
             e.messages[0]["extra"]["response"] = dict(response)
             raise
         message = dict(response["choices"][0]["message"])

--- a/src/minisweagent/models/requesty_model.py
+++ b/src/minisweagent/models/requesty_model.py
@@ -7,6 +7,7 @@ from typing import Any, Literal
 import requests
 from pydantic import BaseModel
 
+from minisweagent.exceptions import FormatError
 from minisweagent.models import GLOBAL_MODEL_STATS
 from minisweagent.models.utils.actions_toolcall import (
     BASH_TOOL,
@@ -104,9 +105,14 @@ class RequestyModel:
                 response = self._query(self._prepare_messages_for_api(messages), **kwargs)
         cost_output = self._calculate_cost(response)
         GLOBAL_MODEL_STATS.add(cost_output["cost"])
+        try:
+            actions = self._parse_actions(response)
+        except FormatError as e:
+            e.messages[0]["extra"]["response"] = response
+            raise
         message = dict(response["choices"][0]["message"])
         message["extra"] = {
-            "actions": self._parse_actions(response),
+            "actions": actions,
             "response": response,
             **cost_output,
             "timestamp": time.time(),

--- a/tests/models/test_format_error_response_persistence.py
+++ b/tests/models/test_format_error_response_persistence.py
@@ -312,3 +312,83 @@ def test_format_error_still_propagates_after_persisting_response() -> None:
         # If the handler silently swallowed FormatError, pytest.raises would fail.
         with pytest.raises(FormatError):
             model.query([{"role": "user", "content": "hi"}])
+
+
+# --------------------------------------------------------------------------- #
+# Text-based models — fix applied via inheritance from parent query()
+# --------------------------------------------------------------------------- #
+
+def test_litellm_textbased_model_format_error_persists_response() -> None:
+    """LitellmTextbasedModel overrides _parse_actions but not query(); the fix
+    must reach the parse_regex_actions code path via inherited query()."""
+    from minisweagent.models.litellm_textbased_model import LitellmTextbasedModel
+
+    response = MagicMock()
+    response.choices = [MagicMock()]
+    # Provide zero actions in content — triggers FormatError in parse_regex_actions.
+    response.choices[0].message.content = "no backtick block here"
+    serialized = {"id": "resp_txt", "choices": [{"message": {"content": "no backtick block here"}}]}
+    response.model_dump.return_value = serialized
+
+    model = LitellmTextbasedModel(model_name="test/model")
+
+    with patch.object(LitellmTextbasedModel, "_query", return_value=response), \
+         patch.object(LitellmTextbasedModel, "_calculate_cost", return_value={"cost": 0.0}):
+        with pytest.raises(FormatError) as excinfo:
+            model.query([{"role": "user", "content": "hi"}])
+
+    extra = excinfo.value.messages[0]["extra"]
+    assert "response" in extra, "response key missing from FormatError extra"
+    assert extra["response"] == serialized
+    json.dumps(extra["response"])  # JSON-serialisable
+    response.model_dump.assert_any_call(mode="json")
+
+
+def test_openrouter_textbased_model_format_error_persists_response() -> None:
+    """OpenRouterTextbasedModel overrides _parse_actions but not query(); the fix
+    must reach the parse_regex_actions code path via inherited query()."""
+    from minisweagent.models.openrouter_textbased_model import OpenRouterTextbasedModel
+
+    # OpenRouterTextbasedModel uses plain dict responses (dict from response.json()).
+    response = {
+        "id": "resp_txt",
+        "model": "test-model",
+        "choices": [{"message": {"role": "assistant", "content": "no backtick block here", "tool_calls": None}}],
+        "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2, "cost": 0.01},
+    }
+
+    model = OpenRouterTextbasedModel(model_name="test/model")
+
+    with patch.object(OpenRouterTextbasedModel, "_query", return_value=response), \
+         patch.object(OpenRouterTextbasedModel, "_calculate_cost", return_value={"cost": 0.01}):
+        with pytest.raises(FormatError) as excinfo:
+            model.query([{"role": "user", "content": "hi"}])
+
+    extra = excinfo.value.messages[0]["extra"]
+    assert "response" in extra, "response key missing from FormatError extra"
+    # OpenRouter/textbased stores dict(response) — a shallow copy of the plain dict.
+    assert extra["response"] == response
+
+
+# --------------------------------------------------------------------------- #
+# ATK-01: model_dump failure inside except block must not swallow FormatError
+# --------------------------------------------------------------------------- #
+
+def test_format_error_not_swallowed_when_model_dump_raises() -> None:
+    """If response.model_dump(mode='json') raises (e.g. serialization error),
+    the original FormatError must still propagate — not an opaque secondary error."""
+    from minisweagent.models.litellm_model import LitellmModel
+
+    response = MagicMock()
+    response.choices = [MagicMock()]
+    response.choices[0].message.tool_calls = [_bad_tool_call_mock()]
+    # Simulate model_dump raising regardless of kwargs.
+    response.model_dump.side_effect = TypeError("unserializable object")
+
+    model = LitellmModel(model_name="test/model")
+
+    with patch.object(LitellmModel, "_query", return_value=response), \
+         patch.object(LitellmModel, "_calculate_cost", return_value={"cost": 0.0}):
+        # Must raise FormatError, not TypeError from the failed model_dump.
+        with pytest.raises(FormatError):
+            model.query([{"role": "user", "content": "hi"}])

--- a/tests/models/test_format_error_response_persistence.py
+++ b/tests/models/test_format_error_response_persistence.py
@@ -429,6 +429,34 @@ def test_litellm_response_model_format_error_not_swallowed_when_model_dump_raise
     assert extra["response"], "repr fallback must be non-empty"
 
 
+def test_portkey_model_format_error_not_swallowed_when_model_dump_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If response.model_dump(mode='json') raises inside the FormatError handler,
+    the original FormatError must still propagate AND extra['response'] must be
+    set to repr(response) — the repr fallback holds for PortkeyModel."""
+    monkeypatch.setenv("PORTKEY_API_KEY", "test-key")
+    from minisweagent.models.portkey_model import PortkeyModel
+
+    response = MagicMock()
+    response.choices = [MagicMock()]
+    response.choices[0].message.tool_calls = [_bad_tool_call_mock()]
+    response.model_dump.side_effect = TypeError("unserializable object")
+
+    with patch("minisweagent.models.portkey_model.Portkey"):
+        model = PortkeyModel(model_name="gpt-4o")
+
+    with patch.object(PortkeyModel, "_query", return_value=response), \
+         patch.object(PortkeyModel, "_calculate_cost", return_value={"cost": 0.0}):
+        with pytest.raises(FormatError) as excinfo:
+            model.query([{"role": "user", "content": "hi"}])
+
+    extra = excinfo.value.messages[0]["extra"]
+    assert "response" in extra, "extra['response'] missing — repr fallback not applied"
+    assert isinstance(extra["response"], str), "repr fallback must produce a string"
+    assert extra["response"], "repr fallback must be non-empty"
+
+
 def test_portkey_response_model_format_error_not_swallowed_when_model_dump_raises(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/models/test_format_error_response_persistence.py
+++ b/tests/models/test_format_error_response_persistence.py
@@ -376,7 +376,8 @@ def test_openrouter_textbased_model_format_error_persists_response() -> None:
 
 def test_format_error_not_swallowed_when_model_dump_raises() -> None:
     """If response.model_dump(mode='json') raises (e.g. serialization error),
-    the original FormatError must still propagate — not an opaque secondary error."""
+    the original FormatError must still propagate AND extra['response'] must be
+    set to repr(response) — the spec contract holds unconditionally."""
     from minisweagent.models.litellm_model import LitellmModel
 
     response = MagicMock()
@@ -390,5 +391,11 @@ def test_format_error_not_swallowed_when_model_dump_raises() -> None:
     with patch.object(LitellmModel, "_query", return_value=response), \
          patch.object(LitellmModel, "_calculate_cost", return_value={"cost": 0.0}):
         # Must raise FormatError, not TypeError from the failed model_dump.
-        with pytest.raises(FormatError):
+        with pytest.raises(FormatError) as excinfo:
             model.query([{"role": "user", "content": "hi"}])
+
+    extra = excinfo.value.messages[0]["extra"]
+    # repr fallback must set the key (spec: response MUST be persisted)
+    assert "response" in extra, "extra['response'] missing — fallback not applied"
+    assert isinstance(extra["response"], str), "repr fallback must produce a string"
+    assert extra["response"], "repr fallback must be non-empty"

--- a/tests/models/test_format_error_response_persistence.py
+++ b/tests/models/test_format_error_response_persistence.py
@@ -163,6 +163,7 @@ def test_openrouter_model_format_error_persists_response() -> None:
     extra = excinfo.value.messages[0]["extra"]
     assert "response" in extra
     assert extra["response"] == response  # plain dict round-trip
+    assert extra["response"] is not response  # must be a copy, not the same object
 
 
 # --------------------------------------------------------------------------- #
@@ -183,6 +184,7 @@ def test_openrouter_response_model_format_error_persists_response() -> None:
     extra = excinfo.value.messages[0]["extra"]
     assert "response" in extra
     assert extra["response"] == response
+    assert extra["response"] is not response  # must be a copy, not the same object
 
 
 # --------------------------------------------------------------------------- #
@@ -263,6 +265,7 @@ def test_requesty_model_format_error_persists_response() -> None:
     extra = excinfo.value.messages[0]["extra"]
     assert "response" in extra
     assert extra["response"] == response
+    assert extra["response"] is not response  # must be a copy, not the same object
 
 
 # --------------------------------------------------------------------------- #
@@ -397,5 +400,59 @@ def test_format_error_not_swallowed_when_model_dump_raises() -> None:
     extra = excinfo.value.messages[0]["extra"]
     # repr fallback must set the key (spec: response MUST be persisted)
     assert "response" in extra, "extra['response'] missing — fallback not applied"
+    assert isinstance(extra["response"], str), "repr fallback must produce a string"
+    assert extra["response"], "repr fallback must be non-empty"
+
+
+def test_litellm_response_model_format_error_not_swallowed_when_model_dump_raises() -> None:
+    """If response.model_dump(mode='json') raises inside the FormatError handler,
+    the original FormatError must still propagate AND extra['response'] must be
+    set to repr(response) — the repr fallback holds for LitellmResponseModel."""
+    from minisweagent.models.litellm_response_model import LitellmResponseModel
+
+    response = MagicMock()
+    response.output = [
+        {"type": "function_call", "call_id": "call_xyz", "name": "unknown_tool", "arguments": "{}"}
+    ]
+    response.model_dump.side_effect = TypeError("unserializable object")
+
+    model = LitellmResponseModel(model_name="test/model")
+
+    with patch.object(LitellmResponseModel, "_query", return_value=response), \
+         patch.object(LitellmResponseModel, "_calculate_cost", return_value={"cost": 0.0}):
+        with pytest.raises(FormatError) as excinfo:
+            model.query([{"role": "user", "content": "hi"}])
+
+    extra = excinfo.value.messages[0]["extra"]
+    assert "response" in extra, "extra['response'] missing — repr fallback not applied"
+    assert isinstance(extra["response"], str), "repr fallback must produce a string"
+    assert extra["response"], "repr fallback must be non-empty"
+
+
+def test_portkey_response_model_format_error_not_swallowed_when_model_dump_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If response.model_dump(mode='json') raises inside the FormatError handler,
+    the original FormatError must still propagate AND extra['response'] must be
+    set to repr(response) — the repr fallback holds for PortkeyResponseAPIModel."""
+    monkeypatch.setenv("PORTKEY_API_KEY", "test-key")
+    from minisweagent.models.portkey_response_model import PortkeyResponseAPIModel
+
+    response = MagicMock()
+    response.output = [
+        {"type": "function_call", "call_id": "call_xyz", "name": "unknown_tool", "arguments": "{}"}
+    ]
+    response.model_dump.side_effect = TypeError("unserializable object")
+
+    with patch("minisweagent.models.portkey_response_model.Portkey"):
+        model = PortkeyResponseAPIModel(model_name="gpt-4o")
+
+    with patch.object(PortkeyResponseAPIModel, "_query", return_value=response), \
+         patch.object(PortkeyResponseAPIModel, "_calculate_cost", return_value={"cost": 0.0}):
+        with pytest.raises(FormatError) as excinfo:
+            model.query([{"role": "user", "content": "hi"}])
+
+    extra = excinfo.value.messages[0]["extra"]
+    assert "response" in extra, "extra['response'] missing — repr fallback not applied"
     assert isinstance(extra["response"], str), "repr fallback must produce a string"
     assert extra["response"], "repr fallback must be non-empty"

--- a/tests/models/test_format_error_response_persistence.py
+++ b/tests/models/test_format_error_response_persistence.py
@@ -1,0 +1,314 @@
+"""Regression tests for issue #784 — FormatError must carry the unparsed
+LLM response in `e.messages[0]["extra"]["response"]` for trajectory inspection.
+
+Each test triggers FormatError via an unrecognised tool name on the parser,
+then asserts that the response payload was persisted into the FormatError's
+extra dict before re-raise. On the pre-fix code these tests fail because
+`e.messages[0]["extra"]` only contains `{"interrupt_type": "FormatError"}`
+and no `response` key.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from minisweagent.exceptions import FormatError
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+def _bad_tool_call_mock() -> MagicMock:
+    """Build a tool-call mock whose function name is not 'bash'."""
+    tc = MagicMock()
+    tc.id = "call_xyz"
+    tc.function.name = "unknown_tool"
+    tc.function.arguments = "{}"
+    return tc
+
+
+def _bad_chat_completion_dict() -> dict[str, Any]:
+    """Plain-dict chat completion payload (OpenRouter/Requesty shape) with bad tool."""
+    return {
+        "id": "resp_1",
+        "model": "test-model",
+        "choices": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_xyz",
+                            "type": "function",
+                            "function": {"name": "unknown_tool", "arguments": "{}"},
+                        }
+                    ],
+                }
+            }
+        ],
+        "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2, "cost": 0.01},
+    }
+
+
+def _bad_response_api_dict() -> dict[str, Any]:
+    """Plain-dict Responses API payload with a bad function_call item."""
+    return {
+        "id": "resp_2",
+        "object": "response",
+        "model": "test-model",
+        "output": [
+            {
+                "type": "function_call",
+                "call_id": "call_xyz",
+                "name": "unknown_tool",
+                "arguments": "{}",
+            }
+        ],
+        "usage": {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+    }
+
+
+# --------------------------------------------------------------------------- #
+# litellm_model.LitellmModel
+# --------------------------------------------------------------------------- #
+
+def test_litellm_model_format_error_persists_response() -> None:
+    from minisweagent.models.litellm_model import LitellmModel
+
+    response = MagicMock()
+    response.choices = [MagicMock()]
+    response.choices[0].message.tool_calls = [_bad_tool_call_mock()]
+    serialized = {"id": "resp_1", "choices": [{"message": {"tool_calls": [{"function": {"name": "unknown_tool"}}]}}]}
+    response.model_dump.return_value = serialized
+
+    model = LitellmModel(model_name="test/model")
+
+    with patch.object(LitellmModel, "_query", return_value=response), \
+         patch.object(LitellmModel, "_calculate_cost", return_value={"cost": 0.0}):
+        with pytest.raises(FormatError) as excinfo:
+            model.query([{"role": "user", "content": "hi"}])
+
+    extra = excinfo.value.messages[0]["extra"]
+    assert "response" in extra, "response key missing — fix not applied"
+    assert extra["response"], "response payload empty — fix not applied"
+    # model_dump(mode='json') was used: result must be JSON-serialisable
+    json.dumps(extra["response"])
+    response.model_dump.assert_any_call(mode="json")
+
+
+# --------------------------------------------------------------------------- #
+# litellm_response_model.LitellmResponseModel
+# --------------------------------------------------------------------------- #
+
+def test_litellm_response_model_format_error_persists_response_with_model_dump() -> None:
+    from minisweagent.models.litellm_response_model import LitellmResponseModel
+
+    response = MagicMock()
+    response.output = [
+        {"type": "function_call", "call_id": "call_xyz", "name": "unknown_tool", "arguments": "{}"}
+    ]
+    serialized = {"id": "resp_2", "output": response.output}
+    response.model_dump.return_value = serialized
+
+    model = LitellmResponseModel(model_name="test/model")
+
+    with patch.object(LitellmResponseModel, "_query", return_value=response), \
+         patch.object(LitellmResponseModel, "_calculate_cost", return_value={"cost": 0.0}):
+        with pytest.raises(FormatError) as excinfo:
+            model.query([{"role": "user", "content": "hi"}])
+
+    extra = excinfo.value.messages[0]["extra"]
+    assert "response" in extra
+    assert extra["response"] == serialized
+    json.dumps(extra["response"])  # JSON-serialisable
+
+
+def test_litellm_response_model_format_error_persists_response_plain_dict_fallback() -> None:
+    """When the response object lacks model_dump, dict(response) is used."""
+    from minisweagent.models.litellm_response_model import LitellmResponseModel
+
+    response = _bad_response_api_dict()  # plain dict, no model_dump
+    model = LitellmResponseModel(model_name="test/model")
+
+    with patch.object(LitellmResponseModel, "_query", return_value=response), \
+         patch.object(LitellmResponseModel, "_calculate_cost", return_value={"cost": 0.0}):
+        with pytest.raises(FormatError) as excinfo:
+            model.query([{"role": "user", "content": "hi"}])
+
+    extra = excinfo.value.messages[0]["extra"]
+    assert "response" in extra
+    assert extra["response"] == response
+
+
+# --------------------------------------------------------------------------- #
+# openrouter_model.OpenRouterModel
+# --------------------------------------------------------------------------- #
+
+def test_openrouter_model_format_error_persists_response() -> None:
+    from minisweagent.models.openrouter_model import OpenRouterModel
+
+    response = _bad_chat_completion_dict()
+    model = OpenRouterModel(model_name="test/model")
+
+    with patch.object(OpenRouterModel, "_query", return_value=response), \
+         patch.object(OpenRouterModel, "_calculate_cost", return_value={"cost": 0.0}):
+        with pytest.raises(FormatError) as excinfo:
+            model.query([{"role": "user", "content": "hi"}])
+
+    extra = excinfo.value.messages[0]["extra"]
+    assert "response" in extra
+    assert extra["response"] == response  # plain dict round-trip
+
+
+# --------------------------------------------------------------------------- #
+# openrouter_response_model.OpenRouterResponseModel
+# --------------------------------------------------------------------------- #
+
+def test_openrouter_response_model_format_error_persists_response() -> None:
+    from minisweagent.models.openrouter_response_model import OpenRouterResponseModel
+
+    response = _bad_response_api_dict()
+    model = OpenRouterResponseModel(model_name="test/model")
+
+    with patch.object(OpenRouterResponseModel, "_query", return_value=response), \
+         patch.object(OpenRouterResponseModel, "_calculate_cost", return_value={"cost": 0.0}):
+        with pytest.raises(FormatError) as excinfo:
+            model.query([{"role": "user", "content": "hi"}])
+
+    extra = excinfo.value.messages[0]["extra"]
+    assert "response" in extra
+    assert extra["response"] == response
+
+
+# --------------------------------------------------------------------------- #
+# portkey_model.PortkeyModel
+# --------------------------------------------------------------------------- #
+
+def test_portkey_model_format_error_persists_response(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PORTKEY_API_KEY", "test-key")
+    from minisweagent.models.portkey_model import PortkeyModel
+
+    response = MagicMock()
+    response.choices = [MagicMock()]
+    response.choices[0].message.tool_calls = [_bad_tool_call_mock()]
+    serialized = {"id": "resp_1", "choices": [{"message": {"tool_calls": [{"function": {"name": "unknown_tool"}}]}}]}
+    response.model_dump.return_value = serialized
+
+    with patch("minisweagent.models.portkey_model.Portkey"):
+        model = PortkeyModel(model_name="gpt-4o")
+
+    with patch.object(PortkeyModel, "_query", return_value=response), \
+         patch.object(PortkeyModel, "_calculate_cost", return_value={"cost": 0.0}):
+        with pytest.raises(FormatError) as excinfo:
+            model.query([{"role": "user", "content": "hi"}])
+
+    extra = excinfo.value.messages[0]["extra"]
+    assert "response" in extra
+    assert extra["response"], "response payload empty — fix not applied"
+    json.dumps(extra["response"])  # JSON-serialisable
+    response.model_dump.assert_any_call(mode="json")
+
+
+# --------------------------------------------------------------------------- #
+# portkey_response_model.PortkeyResponseAPIModel
+# --------------------------------------------------------------------------- #
+
+def test_portkey_response_model_format_error_persists_response_with_model_dump(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PORTKEY_API_KEY", "test-key")
+    from minisweagent.models.portkey_response_model import PortkeyResponseAPIModel
+
+    response = MagicMock()
+    response.output = [
+        {"type": "function_call", "call_id": "call_xyz", "name": "unknown_tool", "arguments": "{}"}
+    ]
+    serialized = {"id": "resp_2", "output": response.output}
+    response.model_dump.return_value = serialized
+
+    with patch("minisweagent.models.portkey_response_model.Portkey"):
+        model = PortkeyResponseAPIModel(model_name="gpt-4o")
+
+    with patch.object(PortkeyResponseAPIModel, "_query", return_value=response), \
+         patch.object(PortkeyResponseAPIModel, "_calculate_cost", return_value={"cost": 0.0}):
+        with pytest.raises(FormatError) as excinfo:
+            model.query([{"role": "user", "content": "hi"}])
+
+    extra = excinfo.value.messages[0]["extra"]
+    assert "response" in extra
+    assert extra["response"] == serialized
+    json.dumps(extra["response"])  # JSON-serialisable
+
+
+# --------------------------------------------------------------------------- #
+# requesty_model.RequestyModel
+# --------------------------------------------------------------------------- #
+
+def test_requesty_model_format_error_persists_response() -> None:
+    from minisweagent.models.requesty_model import RequestyModel
+
+    response = _bad_chat_completion_dict()
+    model = RequestyModel(model_name="test/model")
+
+    with patch.object(RequestyModel, "_query", return_value=response), \
+         patch.object(RequestyModel, "_calculate_cost", return_value={"cost": 0.01}):
+        with pytest.raises(FormatError) as excinfo:
+            model.query([{"role": "user", "content": "hi"}])
+
+    extra = excinfo.value.messages[0]["extra"]
+    assert "response" in extra
+    assert extra["response"] == response
+
+
+# --------------------------------------------------------------------------- #
+# Trajectory log round-trip — the persisted response must JSON-serialise
+# --------------------------------------------------------------------------- #
+
+def test_persisted_response_round_trips_through_json() -> None:
+    """The whole point of the fix is that the trajectory log can dump the
+    payload. If model_dump(mode='json') is missing, datetimes/Decimals leak
+    through and json.dumps raises TypeError."""
+    from minisweagent.models.litellm_model import LitellmModel
+
+    response = MagicMock()
+    response.choices = [MagicMock()]
+    response.choices[0].message.tool_calls = [_bad_tool_call_mock()]
+    response.model_dump.return_value = {"id": "abc", "nested": {"k": "v"}}
+
+    model = LitellmModel(model_name="test/model")
+
+    with patch.object(LitellmModel, "_query", return_value=response), \
+         patch.object(LitellmModel, "_calculate_cost", return_value={"cost": 0.0}):
+        with pytest.raises(FormatError) as excinfo:
+            model.query([{"role": "user", "content": "hi"}])
+
+    # Simulate trajectory log serialisation: dump the whole exception messages.
+    payload = excinfo.value.messages[0]
+    serialised = json.dumps(payload)
+    assert '"response"' in serialised
+    reloaded = json.loads(serialised)
+    assert reloaded["extra"]["response"] == {"id": "abc", "nested": {"k": "v"}}
+
+
+# --------------------------------------------------------------------------- #
+# Contract — FormatError must still propagate (not be swallowed)
+# --------------------------------------------------------------------------- #
+
+def test_format_error_still_propagates_after_persisting_response() -> None:
+    """The except block must re-raise. If a future change accidentally swallows
+    the FormatError (e.g. forgets `raise`), this test catches it."""
+    from minisweagent.models.openrouter_model import OpenRouterModel
+
+    response = _bad_chat_completion_dict()
+    model = OpenRouterModel(model_name="test/model")
+
+    with patch.object(OpenRouterModel, "_query", return_value=response), \
+         patch.object(OpenRouterModel, "_calculate_cost", return_value={"cost": 0.0}):
+        # If the handler silently swallowed FormatError, pytest.raises would fail.
+        with pytest.raises(FormatError):
+            model.query([{"role": "user", "content": "hi"}])

--- a/tests/models/test_format_error_response_persistence.py
+++ b/tests/models/test_format_error_response_persistence.py
@@ -22,6 +22,7 @@ from minisweagent.exceptions import FormatError
 # Helpers
 # --------------------------------------------------------------------------- #
 
+
 def _bad_tool_call_mock() -> MagicMock:
     """Build a tool-call mock whose function name is not 'bash'."""
     tc = MagicMock()
@@ -77,6 +78,7 @@ def _bad_response_api_dict() -> dict[str, Any]:
 # litellm_model.LitellmModel
 # --------------------------------------------------------------------------- #
 
+
 def test_litellm_model_format_error_persists_response() -> None:
     from minisweagent.models.litellm_model import LitellmModel
 
@@ -88,8 +90,10 @@ def test_litellm_model_format_error_persists_response() -> None:
 
     model = LitellmModel(model_name="test/model")
 
-    with patch.object(LitellmModel, "_query", return_value=response), \
-         patch.object(LitellmModel, "_calculate_cost", return_value={"cost": 0.0}):
+    with (
+        patch.object(LitellmModel, "_query", return_value=response),
+        patch.object(LitellmModel, "_calculate_cost", return_value={"cost": 0.0}),
+    ):
         with pytest.raises(FormatError) as excinfo:
             model.query([{"role": "user", "content": "hi"}])
 
@@ -105,20 +109,21 @@ def test_litellm_model_format_error_persists_response() -> None:
 # litellm_response_model.LitellmResponseModel
 # --------------------------------------------------------------------------- #
 
+
 def test_litellm_response_model_format_error_persists_response_with_model_dump() -> None:
     from minisweagent.models.litellm_response_model import LitellmResponseModel
 
     response = MagicMock()
-    response.output = [
-        {"type": "function_call", "call_id": "call_xyz", "name": "unknown_tool", "arguments": "{}"}
-    ]
+    response.output = [{"type": "function_call", "call_id": "call_xyz", "name": "unknown_tool", "arguments": "{}"}]
     serialized = {"id": "resp_2", "output": response.output}
     response.model_dump.return_value = serialized
 
     model = LitellmResponseModel(model_name="test/model")
 
-    with patch.object(LitellmResponseModel, "_query", return_value=response), \
-         patch.object(LitellmResponseModel, "_calculate_cost", return_value={"cost": 0.0}):
+    with (
+        patch.object(LitellmResponseModel, "_query", return_value=response),
+        patch.object(LitellmResponseModel, "_calculate_cost", return_value={"cost": 0.0}),
+    ):
         with pytest.raises(FormatError) as excinfo:
             model.query([{"role": "user", "content": "hi"}])
 
@@ -135,8 +140,10 @@ def test_litellm_response_model_format_error_persists_response_plain_dict_fallba
     response = _bad_response_api_dict()  # plain dict, no model_dump
     model = LitellmResponseModel(model_name="test/model")
 
-    with patch.object(LitellmResponseModel, "_query", return_value=response), \
-         patch.object(LitellmResponseModel, "_calculate_cost", return_value={"cost": 0.0}):
+    with (
+        patch.object(LitellmResponseModel, "_query", return_value=response),
+        patch.object(LitellmResponseModel, "_calculate_cost", return_value={"cost": 0.0}),
+    ):
         with pytest.raises(FormatError) as excinfo:
             model.query([{"role": "user", "content": "hi"}])
 
@@ -149,14 +156,17 @@ def test_litellm_response_model_format_error_persists_response_plain_dict_fallba
 # openrouter_model.OpenRouterModel
 # --------------------------------------------------------------------------- #
 
+
 def test_openrouter_model_format_error_persists_response() -> None:
     from minisweagent.models.openrouter_model import OpenRouterModel
 
     response = _bad_chat_completion_dict()
     model = OpenRouterModel(model_name="test/model")
 
-    with patch.object(OpenRouterModel, "_query", return_value=response), \
-         patch.object(OpenRouterModel, "_calculate_cost", return_value={"cost": 0.0}):
+    with (
+        patch.object(OpenRouterModel, "_query", return_value=response),
+        patch.object(OpenRouterModel, "_calculate_cost", return_value={"cost": 0.0}),
+    ):
         with pytest.raises(FormatError) as excinfo:
             model.query([{"role": "user", "content": "hi"}])
 
@@ -170,14 +180,17 @@ def test_openrouter_model_format_error_persists_response() -> None:
 # openrouter_response_model.OpenRouterResponseModel
 # --------------------------------------------------------------------------- #
 
+
 def test_openrouter_response_model_format_error_persists_response() -> None:
     from minisweagent.models.openrouter_response_model import OpenRouterResponseModel
 
     response = _bad_response_api_dict()
     model = OpenRouterResponseModel(model_name="test/model")
 
-    with patch.object(OpenRouterResponseModel, "_query", return_value=response), \
-         patch.object(OpenRouterResponseModel, "_calculate_cost", return_value={"cost": 0.0}):
+    with (
+        patch.object(OpenRouterResponseModel, "_query", return_value=response),
+        patch.object(OpenRouterResponseModel, "_calculate_cost", return_value={"cost": 0.0}),
+    ):
         with pytest.raises(FormatError) as excinfo:
             model.query([{"role": "user", "content": "hi"}])
 
@@ -190,6 +203,7 @@ def test_openrouter_response_model_format_error_persists_response() -> None:
 # --------------------------------------------------------------------------- #
 # portkey_model.PortkeyModel
 # --------------------------------------------------------------------------- #
+
 
 def test_portkey_model_format_error_persists_response(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("PORTKEY_API_KEY", "test-key")
@@ -204,8 +218,10 @@ def test_portkey_model_format_error_persists_response(monkeypatch: pytest.Monkey
     with patch("minisweagent.models.portkey_model.Portkey"):
         model = PortkeyModel(model_name="gpt-4o")
 
-    with patch.object(PortkeyModel, "_query", return_value=response), \
-         patch.object(PortkeyModel, "_calculate_cost", return_value={"cost": 0.0}):
+    with (
+        patch.object(PortkeyModel, "_query", return_value=response),
+        patch.object(PortkeyModel, "_calculate_cost", return_value={"cost": 0.0}),
+    ):
         with pytest.raises(FormatError) as excinfo:
             model.query([{"role": "user", "content": "hi"}])
 
@@ -220,6 +236,7 @@ def test_portkey_model_format_error_persists_response(monkeypatch: pytest.Monkey
 # portkey_response_model.PortkeyResponseAPIModel
 # --------------------------------------------------------------------------- #
 
+
 def test_portkey_response_model_format_error_persists_response_with_model_dump(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -227,17 +244,17 @@ def test_portkey_response_model_format_error_persists_response_with_model_dump(
     from minisweagent.models.portkey_response_model import PortkeyResponseAPIModel
 
     response = MagicMock()
-    response.output = [
-        {"type": "function_call", "call_id": "call_xyz", "name": "unknown_tool", "arguments": "{}"}
-    ]
+    response.output = [{"type": "function_call", "call_id": "call_xyz", "name": "unknown_tool", "arguments": "{}"}]
     serialized = {"id": "resp_2", "output": response.output}
     response.model_dump.return_value = serialized
 
     with patch("minisweagent.models.portkey_response_model.Portkey"):
         model = PortkeyResponseAPIModel(model_name="gpt-4o")
 
-    with patch.object(PortkeyResponseAPIModel, "_query", return_value=response), \
-         patch.object(PortkeyResponseAPIModel, "_calculate_cost", return_value={"cost": 0.0}):
+    with (
+        patch.object(PortkeyResponseAPIModel, "_query", return_value=response),
+        patch.object(PortkeyResponseAPIModel, "_calculate_cost", return_value={"cost": 0.0}),
+    ):
         with pytest.raises(FormatError) as excinfo:
             model.query([{"role": "user", "content": "hi"}])
 
@@ -251,14 +268,17 @@ def test_portkey_response_model_format_error_persists_response_with_model_dump(
 # requesty_model.RequestyModel
 # --------------------------------------------------------------------------- #
 
+
 def test_requesty_model_format_error_persists_response() -> None:
     from minisweagent.models.requesty_model import RequestyModel
 
     response = _bad_chat_completion_dict()
     model = RequestyModel(model_name="test/model")
 
-    with patch.object(RequestyModel, "_query", return_value=response), \
-         patch.object(RequestyModel, "_calculate_cost", return_value={"cost": 0.01}):
+    with (
+        patch.object(RequestyModel, "_query", return_value=response),
+        patch.object(RequestyModel, "_calculate_cost", return_value={"cost": 0.01}),
+    ):
         with pytest.raises(FormatError) as excinfo:
             model.query([{"role": "user", "content": "hi"}])
 
@@ -271,6 +291,7 @@ def test_requesty_model_format_error_persists_response() -> None:
 # --------------------------------------------------------------------------- #
 # Trajectory log round-trip — the persisted response must JSON-serialise
 # --------------------------------------------------------------------------- #
+
 
 def test_persisted_response_round_trips_through_json() -> None:
     """The whole point of the fix is that the trajectory log can dump the
@@ -285,8 +306,10 @@ def test_persisted_response_round_trips_through_json() -> None:
 
     model = LitellmModel(model_name="test/model")
 
-    with patch.object(LitellmModel, "_query", return_value=response), \
-         patch.object(LitellmModel, "_calculate_cost", return_value={"cost": 0.0}):
+    with (
+        patch.object(LitellmModel, "_query", return_value=response),
+        patch.object(LitellmModel, "_calculate_cost", return_value={"cost": 0.0}),
+    ):
         with pytest.raises(FormatError) as excinfo:
             model.query([{"role": "user", "content": "hi"}])
 
@@ -302,6 +325,7 @@ def test_persisted_response_round_trips_through_json() -> None:
 # Contract — FormatError must still propagate (not be swallowed)
 # --------------------------------------------------------------------------- #
 
+
 def test_format_error_still_propagates_after_persisting_response() -> None:
     """The except block must re-raise. If a future change accidentally swallows
     the FormatError (e.g. forgets `raise`), this test catches it."""
@@ -310,8 +334,10 @@ def test_format_error_still_propagates_after_persisting_response() -> None:
     response = _bad_chat_completion_dict()
     model = OpenRouterModel(model_name="test/model")
 
-    with patch.object(OpenRouterModel, "_query", return_value=response), \
-         patch.object(OpenRouterModel, "_calculate_cost", return_value={"cost": 0.0}):
+    with (
+        patch.object(OpenRouterModel, "_query", return_value=response),
+        patch.object(OpenRouterModel, "_calculate_cost", return_value={"cost": 0.0}),
+    ):
         # If the handler silently swallowed FormatError, pytest.raises would fail.
         with pytest.raises(FormatError):
             model.query([{"role": "user", "content": "hi"}])
@@ -320,6 +346,7 @@ def test_format_error_still_propagates_after_persisting_response() -> None:
 # --------------------------------------------------------------------------- #
 # Text-based models — fix applied via inheritance from parent query()
 # --------------------------------------------------------------------------- #
+
 
 def test_litellm_textbased_model_format_error_persists_response() -> None:
     """LitellmTextbasedModel overrides _parse_actions but not query(); the fix
@@ -335,8 +362,10 @@ def test_litellm_textbased_model_format_error_persists_response() -> None:
 
     model = LitellmTextbasedModel(model_name="test/model")
 
-    with patch.object(LitellmTextbasedModel, "_query", return_value=response), \
-         patch.object(LitellmTextbasedModel, "_calculate_cost", return_value={"cost": 0.0}):
+    with (
+        patch.object(LitellmTextbasedModel, "_query", return_value=response),
+        patch.object(LitellmTextbasedModel, "_calculate_cost", return_value={"cost": 0.0}),
+    ):
         with pytest.raises(FormatError) as excinfo:
             model.query([{"role": "user", "content": "hi"}])
 
@@ -362,8 +391,10 @@ def test_openrouter_textbased_model_format_error_persists_response() -> None:
 
     model = OpenRouterTextbasedModel(model_name="test/model")
 
-    with patch.object(OpenRouterTextbasedModel, "_query", return_value=response), \
-         patch.object(OpenRouterTextbasedModel, "_calculate_cost", return_value={"cost": 0.01}):
+    with (
+        patch.object(OpenRouterTextbasedModel, "_query", return_value=response),
+        patch.object(OpenRouterTextbasedModel, "_calculate_cost", return_value={"cost": 0.01}),
+    ):
         with pytest.raises(FormatError) as excinfo:
             model.query([{"role": "user", "content": "hi"}])
 
@@ -376,6 +407,7 @@ def test_openrouter_textbased_model_format_error_persists_response() -> None:
 # --------------------------------------------------------------------------- #
 # ATK-01: model_dump failure inside except block must not swallow FormatError
 # --------------------------------------------------------------------------- #
+
 
 def test_format_error_not_swallowed_when_model_dump_raises() -> None:
     """If response.model_dump(mode='json') raises (e.g. serialization error),
@@ -391,8 +423,10 @@ def test_format_error_not_swallowed_when_model_dump_raises() -> None:
 
     model = LitellmModel(model_name="test/model")
 
-    with patch.object(LitellmModel, "_query", return_value=response), \
-         patch.object(LitellmModel, "_calculate_cost", return_value={"cost": 0.0}):
+    with (
+        patch.object(LitellmModel, "_query", return_value=response),
+        patch.object(LitellmModel, "_calculate_cost", return_value={"cost": 0.0}),
+    ):
         # Must raise FormatError, not TypeError from the failed model_dump.
         with pytest.raises(FormatError) as excinfo:
             model.query([{"role": "user", "content": "hi"}])
@@ -411,15 +445,15 @@ def test_litellm_response_model_format_error_not_swallowed_when_model_dump_raise
     from minisweagent.models.litellm_response_model import LitellmResponseModel
 
     response = MagicMock()
-    response.output = [
-        {"type": "function_call", "call_id": "call_xyz", "name": "unknown_tool", "arguments": "{}"}
-    ]
+    response.output = [{"type": "function_call", "call_id": "call_xyz", "name": "unknown_tool", "arguments": "{}"}]
     response.model_dump.side_effect = TypeError("unserializable object")
 
     model = LitellmResponseModel(model_name="test/model")
 
-    with patch.object(LitellmResponseModel, "_query", return_value=response), \
-         patch.object(LitellmResponseModel, "_calculate_cost", return_value={"cost": 0.0}):
+    with (
+        patch.object(LitellmResponseModel, "_query", return_value=response),
+        patch.object(LitellmResponseModel, "_calculate_cost", return_value={"cost": 0.0}),
+    ):
         with pytest.raises(FormatError) as excinfo:
             model.query([{"role": "user", "content": "hi"}])
 
@@ -446,8 +480,10 @@ def test_portkey_model_format_error_not_swallowed_when_model_dump_raises(
     with patch("minisweagent.models.portkey_model.Portkey"):
         model = PortkeyModel(model_name="gpt-4o")
 
-    with patch.object(PortkeyModel, "_query", return_value=response), \
-         patch.object(PortkeyModel, "_calculate_cost", return_value={"cost": 0.0}):
+    with (
+        patch.object(PortkeyModel, "_query", return_value=response),
+        patch.object(PortkeyModel, "_calculate_cost", return_value={"cost": 0.0}),
+    ):
         with pytest.raises(FormatError) as excinfo:
             model.query([{"role": "user", "content": "hi"}])
 
@@ -467,16 +503,16 @@ def test_portkey_response_model_format_error_not_swallowed_when_model_dump_raise
     from minisweagent.models.portkey_response_model import PortkeyResponseAPIModel
 
     response = MagicMock()
-    response.output = [
-        {"type": "function_call", "call_id": "call_xyz", "name": "unknown_tool", "arguments": "{}"}
-    ]
+    response.output = [{"type": "function_call", "call_id": "call_xyz", "name": "unknown_tool", "arguments": "{}"}]
     response.model_dump.side_effect = TypeError("unserializable object")
 
     with patch("minisweagent.models.portkey_response_model.Portkey"):
         model = PortkeyResponseAPIModel(model_name="gpt-4o")
 
-    with patch.object(PortkeyResponseAPIModel, "_query", return_value=response), \
-         patch.object(PortkeyResponseAPIModel, "_calculate_cost", return_value={"cost": 0.0}):
+    with (
+        patch.object(PortkeyResponseAPIModel, "_query", return_value=response),
+        patch.object(PortkeyResponseAPIModel, "_calculate_cost", return_value={"cost": 0.0}),
+    ):
         with pytest.raises(FormatError) as excinfo:
             model.query([{"role": "user", "content": "hi"}])
 


### PR DESCRIPTION
When `_parse_actions()` raises a `FormatError`, the trajectory log recorded the error marker but not the raw model response that caused it. The structured response object — tool calls, choices, finish reason — was not preserved, leaving nothing to inspect when debugging format failures.

Closes #784

This PR wraps each wrapper's parse call site in `query()` across all seven model files. On `FormatError`, the response is serialized into `e.messages[0]["extra"]["response"]` before re-raising. If `model_dump()` fails on a non-serializable field, the fallback is `repr(response)`, so `extra["response"]` is always populated. The `FormatError` propagates identically — only the `extra` dict gains a key. No public signatures change.

**Before / after (illustrative)**

```python
# Before — extra on FormatError
{"interrupt_type": "FormatError"}

# After — extra on FormatError
{"interrupt_type": "FormatError", "response": {"id": "chatcmpl-...", "choices": [...], ...}}
```

On the success path, the `try/except` block is never entered and `extra` is unchanged.

The new test file has 16 tests covering all 7 wrappers and the `repr`-fallback path. Each test fails on pre-fix code.

---

<details>
<summary>Pipeline diagram</summary>

```mermaid
flowchart TD
  main(["main-thread orchestrator"])

  subgraph C1 ["layer-1 · planning"]
    a1a["pattern-extractor"] --> a1b["coverage-engineer"]
    a1b --> a1c["contribution-planner"]
    a1c --> a1d["architect-reviewer"]
    a1d -->|objections| a1c
  end

  human1[["human gate · spec approval"]]

  subgraph C2 ["initial-fix"]
    a2["code-author · impl + regression"]
  end

  subgraph C3 ["quality-polish"]
    a3a["readability-editor"] --> a3b["verbosity-trimmer"]
  end

  subgraph C4 ["hygiene-check"]
    a4a["scope-linter"] --> a4b["ci-gate · pre-adversarial"]
  end

  subgraph C5 ["adversarial-loop"]
    atk["attack-pass · senior-reviewer + red-team"]
    rev["revision-pass · senior-engineer + test-author"]
    rrv["re-review-pass · red-team + cold-reviewer"]
    triv{{"triviality-check"}}
    gate["merge-gate"]
    atk --> rev --> rrv --> triv
    triv -->|NON_TRIVIAL| atk
    triv -->|TRIVIAL| gate
  end

  subgraph C6 ["pr-preparation"]
    a6a["project-visionary"] --> a6b["pr-writer"]
    a6b --> a6c["pr-adversary"]
    a6c -->|findings| a6b
    a6b --> a6d["ci-gate · pre-push"]
    a6d --> a6e["license-auditor"]
    a6e --> a6f["workspace-sweep"]
  end

  report[["PRE_PUSH_REPORT · await push approval"]]
  halt1["HALT · plan unstable"]
  halt2["HALT · scope violation"]
  stall["STALLED"]

  main --> C1
  C1 -->|NO_OBJECTIONS| human1
  C1 -.->|EXHAUSTED| halt1
  human1 -->|approved| C2
  human1 -->|rejected| C1
  C2 --> C3 --> C4
  C4 -->|BLOCK| halt2
  C4 -->|PASS| atk
  gate -->|REVISE| atk
  gate -->|APPROVE| C6
  triv -.->|STALL| stall
  C6 --> report

  classDef mainCls fill:#F1EFE8,stroke:#5F5E5A,color:#2C2C2A
  classDef agentCls fill:#EEEDFE,stroke:#534AB7,color:#3C3489
  classDef gateCls fill:#D3D1C7,stroke:#5F5E5A,color:#2C2C2A
  classDef terminalCls fill:#FCEBEB,stroke:#A32D2D,color:#501313
  classDef humanCls fill:#EAF3DE,stroke:#3B6D11,color:#27500A

  class main mainCls
  class a1a,a1b,a1c,a1d,a2,a3a,a3b,a4a,a4b,atk,rev,rrv,a6a,a6b,a6c,a6d,a6e,a6f agentCls
  class triv,gate gateCls
  class halt1,halt2,stall terminalCls
  class human1,report humanCls
```

</details>