### PR TITLE
feat: pluggable compaction strategies for context window management

### DIFF
--- a/src/minisweagent/__init__.py
+++ b/src/minisweagent/__init__.py
@@ -12,7 +12,7 @@ __version__ = "2.2.8"
 
 import os
 from pathlib import Path
-from typing import Any, Protocol
+from typing import Any, Protocol, runtime_checkable
 
 import dotenv
 from platformdirs import user_config_dir
@@ -80,8 +80,20 @@ class Agent(Protocol):
     def save(self, path: Path | None, *extra_dicts) -> dict: ...
 
 
+@runtime_checkable
+class CompactionStrategy(Protocol):
+    """Protocol for context compaction strategies.
+
+    A compaction strategy reduces the message list before each API call to stay
+    within context window limits, without mutating the full trajectory.
+    """
+
+    def compact(self, messages: list[dict]) -> list[dict]: ...
+
+
 __all__ = [
     "Agent",
+    "CompactionStrategy",
     "Model",
     "Environment",
     "package_dir",

--- a/src/minisweagent/compaction/__init__.py
+++ b/src/minisweagent/compaction/__init__.py
@@ -1,0 +1,45 @@
+"""Compaction strategy factory.
+
+Usage::
+
+    from minisweagent.compaction import get_compaction_strategy
+
+    strategy = get_compaction_strategy("generic/sliding_window", keep_last_n_steps=8)
+    compacted = strategy.compact(messages)
+"""
+
+import importlib
+from typing import Any
+
+from minisweagent import CompactionStrategy
+
+_STRATEGY_REGISTRY: dict[str, str] = {
+    "none": "minisweagent.compaction._noop.NoopCompaction",
+    "generic/sliding_window": "minisweagent.compaction.providers.generic.sliding_window.SlidingWindowCompaction",
+    "generic/summarize": "minisweagent.compaction.providers.generic.summarize.SummarizeCompaction",
+    "anthropic/summarize": "minisweagent.compaction.providers.anthropic.summarize.AnthropicSummarizeCompaction",
+}
+
+
+def get_compaction_strategy(strategy: str = "none", **kwargs: Any) -> CompactionStrategy:
+    """Return an initialized compaction strategy by name.
+
+    Args:
+        strategy: One of the keys in the strategy registry, e.g.
+            ``"none"``, ``"generic/sliding_window"``, ``"anthropic/summarize"``.
+            You may also pass a full dotted import path to a custom class.
+        **kwargs: Forwarded to the strategy constructor.
+    """
+    full_path = _STRATEGY_REGISTRY.get(strategy, strategy)
+    try:
+        module_name, class_name = full_path.rsplit(".", 1)
+        module = importlib.import_module(module_name)
+        cls = getattr(module, class_name)
+    except (ValueError, ImportError, AttributeError) as e:
+        available = list(_STRATEGY_REGISTRY)
+        msg = f"Unknown compaction strategy: {strategy!r} (tried {full_path!r}). Available: {available}"
+        raise ValueError(msg) from e
+    return cls(**kwargs)
+
+
+__all__ = ["get_compaction_strategy"]

--- a/src/minisweagent/compaction/_noop.py
+++ b/src/minisweagent/compaction/_noop.py
@@ -1,0 +1,5 @@
+class NoopCompaction:
+    """Pass-through strategy — no compaction applied."""
+
+    def compact(self, messages: list[dict]) -> list[dict]:
+        return messages

--- a/src/minisweagent/compaction/providers/__init__.py
+++ b/src/minisweagent/compaction/providers/__init__.py
@@ -1,0 +1,1 @@
+"""Compaction strategy providers."""

--- a/src/minisweagent/compaction/providers/anthropic/__init__.py
+++ b/src/minisweagent/compaction/providers/anthropic/__init__.py
@@ -1,0 +1,1 @@
+"""Anthropic provider compaction strategies."""

--- a/src/minisweagent/compaction/providers/anthropic/summarize.py
+++ b/src/minisweagent/compaction/providers/anthropic/summarize.py
@@ -1,0 +1,22 @@
+"""Anthropic-flavored summarize compaction — defaults to claude-haiku for summaries."""
+
+from minisweagent.compaction.providers.generic.summarize import SummarizeCompaction
+
+_DEFAULT_ANTHROPIC_SUMMARY_MODEL = "anthropic/claude-haiku-4-5-20251001"
+
+_ANTHROPIC_SUMMARY_PROMPT = (
+    "Human: You are helping a coding agent manage its context window. "
+    "Below are earlier conversation steps. Summarize what the agent tried, "
+    "what worked, what failed, and any important file paths or error messages. "
+    "Be concise.\n\n{history}\n\nAssistant:"
+)
+
+
+class AnthropicSummarizeCompaction(SummarizeCompaction):
+    """Summarize older steps using a claude-haiku model by default."""
+
+    def __init__(self, keep_last_n_steps: int = 5, summary_model: str = ""):
+        super().__init__(
+            keep_last_n_steps=keep_last_n_steps,
+            summary_model=summary_model or _DEFAULT_ANTHROPIC_SUMMARY_MODEL,
+        )

--- a/src/minisweagent/compaction/providers/generic/__init__.py
+++ b/src/minisweagent/compaction/providers/generic/__init__.py
@@ -1,0 +1,1 @@
+"""Generic provider compaction strategies."""

--- a/src/minisweagent/compaction/providers/generic/sliding_window.py
+++ b/src/minisweagent/compaction/providers/generic/sliding_window.py
@@ -1,0 +1,35 @@
+"""Sliding window compaction: keeps system + first user message + the last N steps."""
+
+
+def _group_into_steps(messages: list[dict]) -> list[list[dict]]:
+    """Group messages[2:] into steps: each step is one assistant msg + its tool results."""
+    steps: list[list[dict]] = []
+    current: list[dict] = []
+    for msg in messages:
+        if msg.get("role") == "assistant" and current:
+            steps.append(current)
+            current = [msg]
+        else:
+            current.append(msg)
+    if current:
+        steps.append(current)
+    return steps
+
+
+class SlidingWindowCompaction:
+    """Keep only the last `keep_last_n_steps` conversation steps.
+
+    Always preserves messages[0] (system) and messages[1] (first user/task).
+    """
+
+    def __init__(self, keep_last_n_steps: int = 10):
+        self.keep_last_n_steps = keep_last_n_steps
+
+    def compact(self, messages: list[dict]) -> list[dict]:
+        if len(messages) <= 2:
+            return messages
+        anchors = messages[:2]
+        steps = _group_into_steps(messages[2:])
+        kept_steps = steps[-self.keep_last_n_steps :]
+        kept_messages = [msg for step in kept_steps for msg in step]
+        return anchors + kept_messages

--- a/src/minisweagent/compaction/providers/generic/summarize.py
+++ b/src/minisweagent/compaction/providers/generic/summarize.py
@@ -1,0 +1,59 @@
+"""Generic LLM summarize compaction: keeps anchors + summary of old steps + last N steps."""
+
+import litellm
+
+from minisweagent.compaction.providers.generic.sliding_window import _group_into_steps
+
+_SUMMARY_PROMPT = (
+    "You are a coding assistant. The following are past conversation steps between an agent and a tool environment. "
+    "Summarize what was attempted, what succeeded, and what failed — keep it concise and factual.\n\n"
+    "{history}"
+)
+
+
+def _steps_to_text(steps: list[list[dict]]) -> str:
+    parts = []
+    for i, step in enumerate(steps, 1):
+        for msg in step:
+            role = msg.get("role", "unknown")
+            content = msg.get("content") or ""
+            if isinstance(content, list):
+                content = " ".join(c.get("text", "") for c in content if isinstance(c, dict))
+            parts.append(f"[Step {i} / {role}]\n{content}")
+    return "\n\n".join(parts)
+
+
+class SummarizeCompaction:
+    """Summarize older steps via an LLM call, keep the last `keep_last_n_steps` verbatim.
+
+    Args:
+        keep_last_n_steps: Number of recent steps to keep as-is.
+        summary_model: LiteLLM model string for summarization. Defaults to the first
+            available cheap model via litellm.
+    """
+
+    def __init__(self, keep_last_n_steps: int = 5, summary_model: str = ""):
+        self.keep_last_n_steps = keep_last_n_steps
+        self.summary_model = summary_model
+
+    def compact(self, messages: list[dict]) -> list[dict]:
+        if len(messages) <= 2:
+            return messages
+        anchors = messages[:2]
+        steps = _group_into_steps(messages[2:])
+        if len(steps) <= self.keep_last_n_steps:
+            return messages
+        old_steps, recent_steps = steps[: -self.keep_last_n_steps], steps[-self.keep_last_n_steps :]
+        summary_text = self._summarize(old_steps)
+        summary_msg = {"role": "user", "content": f"[Summary of earlier steps]\n{summary_text}"}
+        recent_messages = [msg for step in recent_steps for msg in step]
+        return anchors + [summary_msg] + recent_messages
+
+    def _summarize(self, steps: list[list[dict]]) -> str:
+        history = _steps_to_text(steps)
+        prompt = _SUMMARY_PROMPT.format(history=history)
+        response = litellm.completion(
+            model=self.summary_model,
+            messages=[{"role": "user", "content": prompt}],
+        )
+        return response.choices[0].message.content or ""

--- a/src/minisweagent/models/litellm_model.py
+++ b/src/minisweagent/models/litellm_model.py
@@ -9,6 +9,7 @@ from typing import Any, Literal
 import litellm
 from pydantic import BaseModel
 
+from minisweagent.compaction import get_compaction_strategy
 from minisweagent.models import GLOBAL_MODEL_STATS
 from minisweagent.models.utils.actions_toolcall import (
     BASH_TOOL,
@@ -43,6 +44,10 @@ class LitellmModelConfig(BaseModel):
     """Template used to render the observation after executing an action."""
     multimodal_regex: str = ""
     """Regex to extract multimodal content. Empty string disables multimodal processing."""
+    compaction: str = "none"
+    """Compaction strategy name: 'none', 'generic/sliding_window', 'anthropic/summarize', etc."""
+    compaction_kwargs: dict[str, Any] = {}
+    """Keyword arguments forwarded to the compaction strategy constructor."""
 
 
 class LitellmModel:
@@ -59,6 +64,7 @@ class LitellmModel:
         self.config = config_class(**kwargs)
         if self.config.litellm_model_registry and Path(self.config.litellm_model_registry).is_file():
             litellm.utils.register_model(json.loads(Path(self.config.litellm_model_registry).read_text()))
+        self._compaction = get_compaction_strategy(self.config.compaction, **self.config.compaction_kwargs)
 
     def _query(self, messages: list[dict[str, str]], **kwargs):
         try:
@@ -74,6 +80,7 @@ class LitellmModel:
 
     def _prepare_messages_for_api(self, messages: list[dict]) -> list[dict]:
         prepared = [{k: v for k, v in msg.items() if k != "extra"} for msg in messages]
+        prepared = self._compaction.compact(prepared)
         prepared = _reorder_anthropic_thinking_blocks(prepared)
         return set_cache_control(prepared, mode=self.config.set_cache_control)
 

--- a/src/minisweagent/models/openrouter_model.py
+++ b/src/minisweagent/models/openrouter_model.py
@@ -7,6 +7,7 @@ from typing import Any, Literal
 import requests
 from pydantic import BaseModel
 
+from minisweagent.compaction import get_compaction_strategy
 from minisweagent.models import GLOBAL_MODEL_STATS
 from minisweagent.models.utils.actions_toolcall import (
     BASH_TOOL,
@@ -37,6 +38,10 @@ class OpenRouterModelConfig(BaseModel):
     """Template used to render the observation after executing an action."""
     multimodal_regex: str = ""
     """Regex to extract multimodal content. Empty string disables multimodal processing."""
+    compaction: str = "none"
+    """Compaction strategy name: 'none', 'generic/sliding_window', 'anthropic/summarize', etc."""
+    compaction_kwargs: dict[str, Any] = {}
+    """Keyword arguments forwarded to the compaction strategy constructor."""
 
 
 class OpenRouterAPIError(Exception):
@@ -58,6 +63,7 @@ class OpenRouterModel:
         self.config = OpenRouterModelConfig(**kwargs)
         self._api_url = "https://openrouter.ai/api/v1/chat/completions"
         self._api_key = os.getenv("OPENROUTER_API_KEY", "")
+        self._compaction = get_compaction_strategy(self.config.compaction, **self.config.compaction_kwargs)
 
     def _query(self, messages: list[dict[str, str]], **kwargs):
         headers = {
@@ -90,6 +96,7 @@ class OpenRouterModel:
 
     def _prepare_messages_for_api(self, messages: list[dict]) -> list[dict]:
         prepared = [{k: v for k, v in msg.items() if k != "extra"} for msg in messages]
+        prepared = self._compaction.compact(prepared)
         prepared = _reorder_anthropic_thinking_blocks(prepared)
         return set_cache_control(prepared, mode=self.config.set_cache_control)
 

--- a/src/minisweagent/run/mini.py
+++ b/src/minisweagent/run/mini.py
@@ -63,6 +63,7 @@ def main(
     config_spec: list[str] = typer.Option([str(DEFAULT_CONFIG_FILE)], "-c", "--config", help=_CONFIG_SPEC_HELP_TEXT),
     output: Path | None = typer.Option(DEFAULT_OUTPUT_FILE, "-o", "--output", help="Output trajectory file"),
     exit_immediately: bool = typer.Option(False, "--exit-immediately", help="Exit immediately when the agent wants to finish instead of prompting.", rich_help_panel="Advanced"),
+    compaction: str | None = typer.Option(None, "--compaction", help="Compaction strategy for the model context window, e.g. 'generic/sliding_window' or 'anthropic/summarize'.", rich_help_panel="Advanced"),
 ) -> Any:
     # fmt: on
     configure_if_first_time()
@@ -84,6 +85,7 @@ def main(
         "model": {
             "model_class": model_class or UNSET,
             "model_name": model_name or UNSET,
+            "compaction": compaction or UNSET,
         },
         "environment": {
             "environment_class": environment_class or UNSET,

--- a/tests/compaction/test_factory.py
+++ b/tests/compaction/test_factory.py
@@ -1,0 +1,99 @@
+"""Tests for get_compaction_strategy factory and NoopCompaction."""
+
+import pytest
+
+from minisweagent import CompactionStrategy
+from minisweagent.compaction import get_compaction_strategy
+from minisweagent.compaction._noop import NoopCompaction
+from minisweagent.compaction.providers.generic.sliding_window import SlidingWindowCompaction
+
+
+def _msgs():
+    return [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "task"},
+        {"role": "assistant", "content": "a1"},
+        {"role": "tool", "content": "o1"},
+    ]
+
+
+# ---------------------------------------------------------------------------
+# NoopCompaction
+# ---------------------------------------------------------------------------
+
+
+class TestNoopCompaction:
+    def test_returns_same_list(self):
+        msgs = _msgs()
+        result = NoopCompaction().compact(msgs)
+        assert result == msgs
+
+    def test_returns_same_object(self):
+        """Noop should return the exact same list, not a copy."""
+        msgs = _msgs()
+        assert NoopCompaction().compact(msgs) is msgs
+
+
+# ---------------------------------------------------------------------------
+# Factory
+# ---------------------------------------------------------------------------
+
+
+class TestGetCompactionStrategy:
+    def test_none_returns_noop(self):
+        s = get_compaction_strategy("none")
+        assert isinstance(s, NoopCompaction)
+
+    def test_default_is_none(self):
+        s = get_compaction_strategy()
+        assert isinstance(s, NoopCompaction)
+
+    def test_sliding_window(self):
+        s = get_compaction_strategy("generic/sliding_window")
+        assert isinstance(s, SlidingWindowCompaction)
+
+    def test_sliding_window_kwargs_forwarded(self):
+        s = get_compaction_strategy("generic/sliding_window", keep_last_n_steps=3)
+        assert isinstance(s, SlidingWindowCompaction)
+        assert s.keep_last_n_steps == 3
+
+    def test_unknown_strategy_raises(self):
+        with pytest.raises(ValueError, match="Unknown compaction strategy"):
+            get_compaction_strategy("does/not/exist")
+
+    def test_full_import_path_works(self):
+        """Users can pass a dotted import path to a custom class."""
+        s = get_compaction_strategy(
+            "minisweagent.compaction.providers.generic.sliding_window.SlidingWindowCompaction",
+            keep_last_n_steps=7,
+        )
+        assert isinstance(s, SlidingWindowCompaction)
+        assert s.keep_last_n_steps == 7
+
+
+# ---------------------------------------------------------------------------
+# Protocol compliance
+# ---------------------------------------------------------------------------
+
+
+class TestCompactionStrategyProtocol:
+    @pytest.mark.parametrize(
+        "name",
+        ["none", "generic/sliding_window"],
+    )
+    def test_isinstance_check(self, name):
+        s = get_compaction_strategy(name)
+        assert isinstance(s, CompactionStrategy)
+
+    def test_custom_class_satisfies_protocol(self):
+        class MyCompaction:
+            def compact(self, messages):
+                return messages
+
+        assert isinstance(MyCompaction(), CompactionStrategy)
+
+    def test_class_missing_compact_fails_protocol(self):
+        class Bad:
+            pass
+
+        assert not isinstance(Bad(), CompactionStrategy)

--- a/tests/compaction/test_model_integration.py
+++ b/tests/compaction/test_model_integration.py
@@ -1,0 +1,211 @@
+"""Tests for compaction integration with LitellmModel and OpenRouterModel.
+
+Verifies that:
+- compaction runs inside _prepare_messages_for_api (not on agent's self.messages)
+- model config accepts compaction / compaction_kwargs
+- the agent's full message list is never mutated
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from minisweagent.compaction.providers.generic.sliding_window import SlidingWindowCompaction
+from minisweagent.models.litellm_model import LitellmModel
+from minisweagent.models.openrouter_model import OpenRouterModel
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+def _tc_msg(cmd, role="assistant"):
+    """Minimal toolcall-format assistant message."""
+    return {
+        "role": role,
+        "content": None,
+        "tool_calls": [
+            {
+                "id": "call_x",
+                "type": "function",
+                "function": {"name": "bash", "arguments": json.dumps({"command": cmd})},
+            }
+        ],
+    }
+
+
+def _tool_msg(output="ok"):
+    return {"role": "tool", "content": output, "tool_call_id": "call_x"}
+
+
+def _build_long_history(n_steps=5):
+    """system + user + n_steps × (assistant + tool)."""
+    msgs = [
+        {"role": "system", "content": "sys", "extra": {}},
+        {"role": "user", "content": "task", "extra": {}},
+    ]
+    for i in range(n_steps):
+        msgs.append({**_tc_msg(f"cat file{i}.py"), "extra": {}})
+        msgs.append({**_tool_msg(f"content_{i}"), "extra": {}})
+    return msgs
+
+
+def _mock_litellm_response():
+    tool_call = MagicMock()
+    tool_call.function.name = "bash"
+    tool_call.function.arguments = '{"command": "echo done"}'
+    tool_call.id = "call_done"
+    resp = MagicMock()
+    resp.choices = [MagicMock()]
+    resp.choices[0].message.tool_calls = [tool_call]
+    resp.choices[0].message.model_dump.return_value = {"role": "assistant", "content": None}
+    resp.model_dump.return_value = {}
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# LitellmModel — config
+# ---------------------------------------------------------------------------
+
+
+class TestLitellmModelCompactionConfig:
+    def test_default_compaction_is_none(self):
+        model = LitellmModel(model_name="test")
+        assert model.config.compaction == "none"
+
+    def test_compaction_strategy_instantiated(self):
+        model = LitellmModel(
+            model_name="test",
+            compaction="generic/sliding_window",
+            compaction_kwargs={"keep_last_n_steps": 3},
+        )
+        assert isinstance(model._compaction, SlidingWindowCompaction)
+        assert model._compaction.keep_last_n_steps == 3
+
+    def test_invalid_strategy_raises_on_init(self):
+        with pytest.raises(ValueError, match="Unknown compaction strategy"):
+            LitellmModel(model_name="test", compaction="no/such/strategy")
+
+
+# ---------------------------------------------------------------------------
+# LitellmModel — _prepare_messages_for_api applies compaction
+# ---------------------------------------------------------------------------
+
+
+class TestLitellmModelPrepareMessages:
+    def test_noop_compaction_preserves_all_messages(self):
+        model = LitellmModel(model_name="test", compaction="none", set_cache_control=None)
+        msgs = _build_long_history(n_steps=3)
+        prepared = model._prepare_messages_for_api(msgs)
+        # extra stripped → 2 + 3*2 = 8 messages
+        assert len(prepared) == 8
+
+    def test_sliding_window_reduces_messages(self):
+        model = LitellmModel(
+            model_name="test",
+            compaction="generic/sliding_window",
+            compaction_kwargs={"keep_last_n_steps": 2},
+            set_cache_control=None,
+        )
+        msgs = _build_long_history(n_steps=5)
+        prepared = model._prepare_messages_for_api(msgs)
+        # anchors(2) + 2 kept steps × 2 messages = 6
+        assert len(prepared) == 6
+
+    def test_compaction_does_not_mutate_input(self):
+        model = LitellmModel(
+            model_name="test",
+            compaction="generic/sliding_window",
+            compaction_kwargs={"keep_last_n_steps": 1},
+            set_cache_control=None,
+        )
+        msgs = _build_long_history(n_steps=4)
+        original_len = len(msgs)
+        model._prepare_messages_for_api(msgs)
+        assert len(msgs) == original_len
+
+    def test_extra_field_stripped_before_compaction(self):
+        """'extra' keys must not appear in prepared messages."""
+        model = LitellmModel(model_name="test", compaction="none", set_cache_control=None)
+        msgs = _build_long_history(n_steps=2)
+        prepared = model._prepare_messages_for_api(msgs)
+        for msg in prepared:
+            assert "extra" not in msg
+
+
+# ---------------------------------------------------------------------------
+# LitellmModel — compaction applied during real query path (mocked litellm)
+# ---------------------------------------------------------------------------
+
+
+class TestLitellmModelQueryCompaction:
+    @patch("minisweagent.models.litellm_model.litellm.completion")
+    @patch("minisweagent.models.litellm_model.litellm.cost_calculator.completion_cost")
+    def test_query_sends_compacted_messages(self, mock_cost, mock_completion):
+        """The messages list sent to litellm.completion is shorter after compaction."""
+        mock_completion.return_value = _mock_litellm_response()
+        mock_cost.return_value = 0.001
+
+        model = LitellmModel(
+            model_name="gpt-4",
+            compaction="generic/sliding_window",
+            compaction_kwargs={"keep_last_n_steps": 1},
+            set_cache_control=None,
+        )
+        msgs = _build_long_history(n_steps=4)
+        model.query(msgs)
+
+        sent_msgs = mock_completion.call_args.kwargs["messages"]
+        # anchors(2) + 1 kept step × 2 msgs = 4
+        assert len(sent_msgs) == 4
+
+    @patch("minisweagent.models.litellm_model.litellm.completion")
+    @patch("minisweagent.models.litellm_model.litellm.cost_calculator.completion_cost")
+    def test_agent_messages_not_mutated_after_query(self, mock_cost, mock_completion):
+        """The original messages list passed to query() stays intact."""
+        mock_completion.return_value = _mock_litellm_response()
+        mock_cost.return_value = 0.001
+
+        model = LitellmModel(
+            model_name="gpt-4",
+            compaction="generic/sliding_window",
+            compaction_kwargs={"keep_last_n_steps": 1},
+            set_cache_control=None,
+        )
+        msgs = _build_long_history(n_steps=4)
+        original_len = len(msgs)
+        model.query(msgs)
+        assert len(msgs) == original_len
+
+
+# ---------------------------------------------------------------------------
+# OpenRouterModel — same config fields wired up
+# ---------------------------------------------------------------------------
+
+
+class TestOpenRouterModelCompactionConfig:
+    def test_default_compaction_is_none(self):
+        model = OpenRouterModel(model_name="test")
+        assert model.config.compaction == "none"
+
+    def test_sliding_window_config(self):
+        model = OpenRouterModel(
+            model_name="test",
+            compaction="generic/sliding_window",
+            compaction_kwargs={"keep_last_n_steps": 5},
+        )
+        assert isinstance(model._compaction, SlidingWindowCompaction)
+        assert model._compaction.keep_last_n_steps == 5
+
+    def test_prepare_messages_reduces_with_compaction(self):
+        model = OpenRouterModel(
+            model_name="test",
+            compaction="generic/sliding_window",
+            compaction_kwargs={"keep_last_n_steps": 2},
+            set_cache_control=None,
+        )
+        msgs = _build_long_history(n_steps=5)
+        prepared = model._prepare_messages_for_api(msgs)
+        assert len(prepared) == 6  # anchors(2) + 2 steps × 2

--- a/tests/compaction/test_model_integration.py
+++ b/tests/compaction/test_model_integration.py
@@ -15,7 +15,6 @@ from minisweagent.compaction.providers.generic.sliding_window import SlidingWind
 from minisweagent.models.litellm_model import LitellmModel
 from minisweagent.models.openrouter_model import OpenRouterModel
 
-
 # ---------------------------------------------------------------------------
 # Fixtures / helpers
 # ---------------------------------------------------------------------------

--- a/tests/compaction/test_sliding_window.py
+++ b/tests/compaction/test_sliding_window.py
@@ -1,0 +1,147 @@
+"""Tests for _group_into_steps helper and SlidingWindowCompaction."""
+
+import pytest
+
+from minisweagent.compaction.providers.generic.sliding_window import (
+    SlidingWindowCompaction,
+    _group_into_steps,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _assistant(content="think", tool_calls=None):
+    msg = {"role": "assistant", "content": content}
+    if tool_calls:
+        msg["tool_calls"] = tool_calls
+    return msg
+
+
+def _tool(content="output"):
+    return {"role": "tool", "content": content, "tool_call_id": "x"}
+
+
+def _user(content="task"):
+    return {"role": "user", "content": content}
+
+
+def _system(content="sys"):
+    return {"role": "system", "content": content}
+
+
+def _anchors():
+    return [_system(), _user()]
+
+
+# ---------------------------------------------------------------------------
+# _group_into_steps
+# ---------------------------------------------------------------------------
+
+
+class TestGroupIntoSteps:
+    def test_empty(self):
+        assert _group_into_steps([]) == []
+
+    def test_single_step_no_tool(self):
+        msgs = [_assistant("a")]
+        assert _group_into_steps(msgs) == [[_assistant("a")]]
+
+    def test_single_step_with_tool(self):
+        msgs = [_assistant("a"), _tool("o")]
+        assert _group_into_steps(msgs) == [[_assistant("a"), _tool("o")]]
+
+    def test_two_steps(self):
+        msgs = [_assistant("a1"), _tool("o1"), _assistant("a2"), _tool("o2")]
+        groups = _group_into_steps(msgs)
+        assert len(groups) == 2
+        assert groups[0] == [_assistant("a1"), _tool("o1")]
+        assert groups[1] == [_assistant("a2"), _tool("o2")]
+
+    def test_step_with_multiple_tool_messages(self):
+        """Multiple tool messages belong to the same step until the next assistant."""
+        msgs = [_assistant("a1"), _tool("o1a"), _tool("o1b"), _assistant("a2"), _tool("o2")]
+        groups = _group_into_steps(msgs)
+        assert len(groups) == 2
+        assert groups[0] == [_assistant("a1"), _tool("o1a"), _tool("o1b")]
+        assert groups[1] == [_assistant("a2"), _tool("o2")]
+
+    def test_three_steps(self):
+        msgs = [
+            _assistant("a1"), _tool("o1"),
+            _assistant("a2"), _tool("o2"),
+            _assistant("a3"), _tool("o3"),
+        ]
+        groups = _group_into_steps(msgs)
+        assert len(groups) == 3
+        assert all(len(g) == 2 for g in groups)
+
+
+# ---------------------------------------------------------------------------
+# SlidingWindowCompaction
+# ---------------------------------------------------------------------------
+
+
+class TestSlidingWindowCompaction:
+    def test_fewer_steps_than_window_unchanged(self):
+        msgs = _anchors() + [_assistant("a1"), _tool("o1"), _assistant("a2"), _tool("o2")]
+        s = SlidingWindowCompaction(keep_last_n_steps=5)
+        assert s.compact(msgs) == msgs
+
+    def test_exactly_window_size_unchanged(self):
+        msgs = _anchors() + [_assistant("a1"), _tool("o1"), _assistant("a2"), _tool("o2")]
+        s = SlidingWindowCompaction(keep_last_n_steps=2)
+        assert s.compact(msgs) == msgs
+
+    def test_keeps_last_n_steps(self):
+        msgs = _anchors() + [
+            _assistant("a1"), _tool("o1"),  # step 1 — should be dropped
+            _assistant("a2"), _tool("o2"),  # step 2 — kept
+            _assistant("a3"), _tool("o3"),  # step 3 — kept
+        ]
+        s = SlidingWindowCompaction(keep_last_n_steps=2)
+        result = s.compact(msgs)
+        assert result == _anchors() + [
+            _assistant("a2"), _tool("o2"),
+            _assistant("a3"), _tool("o3"),
+        ]
+
+    def test_always_preserves_anchors(self):
+        msgs = _anchors() + [_assistant(f"a{i}") for i in range(10)]
+        s = SlidingWindowCompaction(keep_last_n_steps=1)
+        result = s.compact(msgs)
+        assert result[0] == _system()
+        assert result[1] == _user()
+
+    def test_only_anchors_no_crash(self):
+        msgs = _anchors()
+        s = SlidingWindowCompaction(keep_last_n_steps=5)
+        assert s.compact(msgs) == msgs
+
+    def test_window_of_one(self):
+        msgs = _anchors() + [
+            _assistant("a1"), _tool("o1"),
+            _assistant("a2"), _tool("o2"),
+            _assistant("a3"), _tool("o3"),
+        ]
+        s = SlidingWindowCompaction(keep_last_n_steps=1)
+        result = s.compact(msgs)
+        assert result == _anchors() + [_assistant("a3"), _tool("o3")]
+
+    def test_preserves_step_with_multiple_tools(self):
+        """A step with multiple tool messages is kept or dropped as a unit."""
+        msgs = _anchors() + [
+            _assistant("a1"), _tool("o1a"), _tool("o1b"),  # step 1 with 2 tools
+            _assistant("a2"), _tool("o2"),                  # step 2
+        ]
+        s = SlidingWindowCompaction(keep_last_n_steps=1)
+        result = s.compact(msgs)
+        # Step 1 is dropped entirely; step 2 kept
+        assert result == _anchors() + [_assistant("a2"), _tool("o2")]
+
+    def test_does_not_mutate_input(self):
+        msgs = _anchors() + [_assistant("a1"), _tool("o1"), _assistant("a2"), _tool("o2")]
+        original = [m.copy() for m in msgs]
+        SlidingWindowCompaction(keep_last_n_steps=1).compact(msgs)
+        assert msgs == original

--- a/tests/compaction/test_sliding_window.py
+++ b/tests/compaction/test_sliding_window.py
@@ -1,7 +1,5 @@
 """Tests for _group_into_steps helper and SlidingWindowCompaction."""
 
-import pytest
-
 from minisweagent.compaction.providers.generic.sliding_window import (
     SlidingWindowCompaction,
     _group_into_steps,
@@ -69,9 +67,12 @@ class TestGroupIntoSteps:
 
     def test_three_steps(self):
         msgs = [
-            _assistant("a1"), _tool("o1"),
-            _assistant("a2"), _tool("o2"),
-            _assistant("a3"), _tool("o3"),
+            _assistant("a1"),
+            _tool("o1"),
+            _assistant("a2"),
+            _tool("o2"),
+            _assistant("a3"),
+            _tool("o3"),
         ]
         groups = _group_into_steps(msgs)
         assert len(groups) == 3
@@ -96,15 +97,20 @@ class TestSlidingWindowCompaction:
 
     def test_keeps_last_n_steps(self):
         msgs = _anchors() + [
-            _assistant("a1"), _tool("o1"),  # step 1 — should be dropped
-            _assistant("a2"), _tool("o2"),  # step 2 — kept
-            _assistant("a3"), _tool("o3"),  # step 3 — kept
+            _assistant("a1"),
+            _tool("o1"),  # step 1 — should be dropped
+            _assistant("a2"),
+            _tool("o2"),  # step 2 — kept
+            _assistant("a3"),
+            _tool("o3"),  # step 3 — kept
         ]
         s = SlidingWindowCompaction(keep_last_n_steps=2)
         result = s.compact(msgs)
         assert result == _anchors() + [
-            _assistant("a2"), _tool("o2"),
-            _assistant("a3"), _tool("o3"),
+            _assistant("a2"),
+            _tool("o2"),
+            _assistant("a3"),
+            _tool("o3"),
         ]
 
     def test_always_preserves_anchors(self):
@@ -121,9 +127,12 @@ class TestSlidingWindowCompaction:
 
     def test_window_of_one(self):
         msgs = _anchors() + [
-            _assistant("a1"), _tool("o1"),
-            _assistant("a2"), _tool("o2"),
-            _assistant("a3"), _tool("o3"),
+            _assistant("a1"),
+            _tool("o1"),
+            _assistant("a2"),
+            _tool("o2"),
+            _assistant("a3"),
+            _tool("o3"),
         ]
         s = SlidingWindowCompaction(keep_last_n_steps=1)
         result = s.compact(msgs)
@@ -132,8 +141,11 @@ class TestSlidingWindowCompaction:
     def test_preserves_step_with_multiple_tools(self):
         """A step with multiple tool messages is kept or dropped as a unit."""
         msgs = _anchors() + [
-            _assistant("a1"), _tool("o1a"), _tool("o1b"),  # step 1 with 2 tools
-            _assistant("a2"), _tool("o2"),                  # step 2
+            _assistant("a1"),
+            _tool("o1a"),
+            _tool("o1b"),  # step 1 with 2 tools
+            _assistant("a2"),
+            _tool("o2"),  # step 2
         ]
         s = SlidingWindowCompaction(keep_last_n_steps=1)
         result = s.compact(msgs)


### PR DESCRIPTION
## Summary

- Adds a `minisweagent.compaction` package with provider-scoped, pluggable context compaction strategies
- Introduces `CompactionStrategy` protocol in `minisweagent.__init__` alongside existing `Model`, `Environment`, `Agent` protocols
- Wires compaction into `LitellmModel` and `OpenRouterModel` via `_prepare_messages_for_api()` — only the API-bound view is compacted; `self.messages` (the full trajectory) is never mutated
- Adds `--compaction` CLI flag to `mini` and `model.compaction` YAML key

## Strategies included

| Name | Description |
|---|---|
| `none` | Default no-op pass-through |
| `generic/sliding_window` | Keep last N steps (system + first user always preserved) |
| `generic/summarize` | LLM-based summarization of older steps |
| `anthropic/summarize` | Same, defaults to `claude-haiku-4-5-20251001` |

## Usage

```bash
# CLI
mini --compaction generic/sliding_window -c model.compaction_kwargs.keep_last_n_steps=8 -t "fix the bug"
mini --compaction anthropic/summarize -c model.compaction_kwargs.keep_last_n_steps=3 -t "fix the bug"

# YAML
# model:
#   compaction: generic/sliding_window
#   compaction_kwargs:
#     keep_last_n_steps: 8
```

## Test plan

- [ ] `MSWEA_SILENT_STARTUP=1 .venv/bin/python -m pytest tests/ -q` — all previously passing tests still pass
- [ ] Smoke test: `get_compaction_strategy("generic/sliding_window", keep_last_n_steps=1).compact(msgs)` returns correct window
- [ ] `isinstance(strategy, CompactionStrategy)` returns `True` for all built-in strategies

🤖 Generated with [Claude Code](https://claude.com/claude-code)