### PR TITLE
fix: add wall-clock time limit to properly kill agents

### DIFF
--- a/src/minisweagent/agents/default.py
+++ b/src/minisweagent/agents/default.py
@@ -4,6 +4,7 @@ or https://minimal-agent.com for a tutorial on the basic building principles.
 
 import json
 import logging
+import time
 import traceback
 from pathlib import Path
 
@@ -11,7 +12,7 @@ from jinja2 import StrictUndefined, Template
 from pydantic import BaseModel
 
 from minisweagent import Environment, Model, __version__
-from minisweagent.exceptions import InterruptAgentFlow, LimitsExceeded
+from minisweagent.exceptions import InterruptAgentFlow, LimitsExceeded, TimeExceeded
 from minisweagent.utils.serialize import recursive_merge
 
 
@@ -26,6 +27,8 @@ class AgentConfig(BaseModel):
     """Maximum number of steps the agent can take."""
     cost_limit: float = 3.0
     """Stop agent after exceeding (!) this cost."""
+    wall_time_limit_seconds: int = 0
+    """Stop agent after this many seconds of wall-clock time. 0 means no limit."""
     output_path: Path | None = None
     """Save the trajectory to this path."""
 
@@ -41,13 +44,18 @@ class DefaultAgent:
         self.logger = logging.getLogger("agent")
         self.cost = 0.0
         self.n_calls = 0
+        self._start_time = time.time()
 
     def get_template_vars(self, **kwargs) -> dict:
         return recursive_merge(
             self.config.model_dump(),
             self.env.get_template_vars(),
             self.model.get_template_vars(),
-            {"n_model_calls": self.n_calls, "model_cost": self.cost},
+            {
+                "n_model_calls": self.n_calls,
+                "model_cost": self.cost,
+                "elapsed_seconds": int(time.time() - self._start_time),
+            },
             self.extra_template_vars,
             kwargs,
         )
@@ -108,6 +116,14 @@ class DefaultAgent:
                     "role": "exit",
                     "content": "LimitsExceeded",
                     "extra": {"exit_status": "LimitsExceeded", "submission": ""},
+                }
+            )
+        if 0 < self.config.wall_time_limit_seconds <= int(time.time() - self._start_time):
+            raise TimeExceeded(
+                {
+                    "role": "exit",
+                    "content": "TimeExceeded",
+                    "extra": {"exit_status": "TimeExceeded", "submission": ""},
                 }
             )
         self.n_calls += 1

--- a/src/minisweagent/exceptions.py
+++ b/src/minisweagent/exceptions.py
@@ -14,6 +14,10 @@ class LimitsExceeded(InterruptAgentFlow):
     """Raised when the agent has exceeded its cost or step limit."""
 
 
+class TimeExceeded(LimitsExceeded):
+    """Raised when the agent has exceeded its wall-clock time limit."""
+
+
 class UserInterruption(InterruptAgentFlow):
     """Raised when the user interrupts the agent."""
 

--- a/tests/agents/test_default.py
+++ b/tests/agents/test_default.py
@@ -405,6 +405,39 @@ def test_observations_captured(model_factory):
     assert "second" in observations[1]
 
 
+def test_wall_time_limit_enforcement(model_factory):
+    """Test agent stops when wall-clock time limit is reached."""
+    factory, config = model_factory
+    agent = DefaultAgent(
+        model=factory(
+            [
+                ("Slow command", [{"command": "sleep 2"}]),
+                ("Should not run", [{"command": "echo 'unreachable'"}]),
+            ]
+        ),
+        env=LocalEnvironment(),
+        **{**config, "wall_time_limit_seconds": 1},
+    )
+
+    info = agent.run("Test wall time limit")
+    assert info["exit_status"] == "TimeExceeded"
+    assert agent.n_calls == 1
+
+
+def test_wall_time_limit_template_vars(model_factory):
+    """Test that elapsed_seconds and wall_time_limit_seconds are available as template vars."""
+    factory, config = model_factory
+    agent = DefaultAgent(
+        model=factory([("Test", [{"command": "echo 'test'"}])]),
+        env=LocalEnvironment(),
+        **{**config, "wall_time_limit_seconds": 3600},
+    )
+    agent.add_messages({"role": "system", "content": "test"}, {"role": "user", "content": "test"})
+    tvars = agent.get_template_vars()
+    assert isinstance(tvars["elapsed_seconds"], int)
+    assert tvars["wall_time_limit_seconds"] == 3600
+
+
 def test_empty_actions_handling(model_factory):
     """Test agent handles empty actions (continues without error)."""
     factory, config = model_factory


### PR DESCRIPTION
When container_timeout expires and Docker removes the container (--rm),
the agent keeps issuing commands and burning API calls. Add a
wall_time_limit_seconds config option that cleanly stops the agent via
TimeExceeded before the container can die.
