### PR TITLE
docs: fix broken banner link

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block announce %}
-<a href="{{ config.site_url }}/latest/usage/programbench/">
+<a href="{{ 'usage/programbench/' | url }}">
   🎉 Run mini-swe-agent on our new & extremely challenging benchmark, ProgramBench
 </a>
 {% endblock %}


### PR DESCRIPTION
The banner was adding latest twice, so the link pointed to: `/latest/latest/usage/programbench/`
Use a docs-relative link instead so MkDocs builds the correct URL.