### PR TITLE
Don't prompt for new limits when stdin is non-interactive

### DIFF
--- a/src/minisweagent/agents/interactive.py
+++ b/src/minisweagent/agents/interactive.py
@@ -7,6 +7,7 @@ There are three modes:
 """
 
 import re
+import sys
 from typing import Literal, NoReturn
 
 from rich.console import Console
@@ -14,7 +15,7 @@ from rich.rule import Rule
 
 from minisweagent.agents.default import AgentConfig, DefaultAgent
 from minisweagent.agents.utils.prompt_user import _multiline_prompt, prompt_session
-from minisweagent.exceptions import LimitsExceeded, Submitted, UserInterruption
+from minisweagent.exceptions import LimitsExceeded, Submitted, TimeExceeded, UserInterruption
 from minisweagent.models.utils.content_string import get_content_string
 
 console = Console(highlight=False)
@@ -71,7 +72,19 @@ class InteractiveAgent(DefaultAgent):
         try:
             with console.status("Waiting for the LM to respond..."):
                 return super().query()
+        except TimeExceeded:
+            # A wall-clock limit can't be lifted by raising the step/cost limits
+            # (the next query re-checks the clock and raises again), so prompting
+            # would loop forever. Always stop cleanly instead.
+            raise
         except LimitsExceeded:
+            if not self._stdin_is_interactive():
+                # No terminal to prompt for new limits -- e.g. an unattended
+                # `--yolo` run, or any run with stdin redirected from /dev/null
+                # (CI, a sandbox). Stop cleanly so the trajectory is saved with a
+                # LimitsExceeded exit status, instead of crashing on EOFError when
+                # reading input.
+                raise
             console.print(
                 f"Limits exceeded. Limits: {self.config.step_limit} steps, ${self.config.cost_limit}.\n"
                 f"Current spend: {self.n_calls} steps, ${self.cost:.2f}."
@@ -79,6 +92,19 @@ class InteractiveAgent(DefaultAgent):
             self.config.step_limit = int(input("New step limit: "))
             self.config.cost_limit = float(input("New cost limit: "))
             return super().query()
+
+    @staticmethod
+    def _stdin_is_interactive() -> bool:
+        """Whether an interactive terminal is available to prompt the user.
+
+        Returns False for unattended runs (e.g. `--yolo` in CI, or inside a
+        sandbox with stdin redirected from /dev/null), where calling ``input()``
+        would raise ``EOFError`` and crash the run.
+        """
+        try:
+            return sys.stdin is not None and sys.stdin.isatty()
+        except (ValueError, OSError):
+            return False
 
     def step(self) -> list[dict]:
         # Override the step method to handle user interruption

--- a/tests/agents/test_interactive.py
+++ b/tests/agents/test_interactive.py
@@ -837,11 +837,13 @@ def test_limits_exceeded_with_user_continuation(model_factory):
         },
     )
 
-    # Mock input() to provide new limits when prompted
-    with patch("builtins.input", side_effect=["10", "5.0"]):  # New step_limit=10, cost_limit=5.0
-        with mock_prompts([""]):  # No new task
-            with patch("minisweagent.agents.interactive.console.print"):  # Suppress console output
-                info = agent.run("Test limits exceeded with continuation")
+    # Mock input() to provide new limits when prompted (simulating an
+    # interactive terminal, so isatty() must report True).
+    with patch.object(InteractiveAgent, "_stdin_is_interactive", return_value=True):
+        with patch("builtins.input", side_effect=["10", "5.0"]):  # New step_limit=10, cost_limit=5.0
+            with mock_prompts([""]):  # No new task
+                with patch("minisweagent.agents.interactive.console.print"):  # Suppress console output
+                    info = agent.run("Test limits exceeded with continuation")
 
     assert info["exit_status"] == "Submitted"
     assert info["submission"] == "completed after limit increase\n"
@@ -880,17 +882,69 @@ def test_limits_exceeded_multiple_times_with_continuation(model_factory):
         },
     )
 
-    # Mock input() to provide new limits multiple times
+    # Mock input() to provide new limits multiple times (interactive terminal).
     # First limit increase: step_limit=2, then step_limit=10 when exceeded again
-    with patch("builtins.input", side_effect=["2", "100.0", "10", "100.0"]):
-        with mock_prompts([""]):  # No new task
-            with patch("minisweagent.agents.interactive.console.print"):
-                info = agent.run("Test multiple limit increases")
+    with patch.object(InteractiveAgent, "_stdin_is_interactive", return_value=True):
+        with patch("builtins.input", side_effect=["2", "100.0", "10", "100.0"]):
+            with mock_prompts([""]):  # No new task
+                with patch("minisweagent.agents.interactive.console.print"):
+                    info = agent.run("Test multiple limit increases")
 
     assert info["exit_status"] == "Submitted"
     assert info["submission"] == "completed after multiple increases\n"
     assert agent.n_calls == 5  # Should complete all 5 steps
     assert agent.config.step_limit == 10  # Should have final updated step limit
+
+
+def test_limits_exceeded_non_interactive_stops_cleanly(model_factory):
+    """Without a terminal (e.g. `--yolo` in CI / a sandbox), a breached limit must
+    stop cleanly with a LimitsExceeded exit status instead of crashing on EOFError
+    when trying to prompt for new limits."""
+    factory, config = model_factory
+    agent = InteractiveAgent(
+        model=factory(
+            [("Step 1", [{"command": "echo 'first step'"}])],
+            cost_per_call=0.6,  # exceeds cost_limit after the first call
+        ),
+        env=LocalEnvironment(),
+        **{
+            **config,
+            "step_limit": 10,
+            "cost_limit": 0.5,
+            "mode": "yolo",
+        },
+    )
+
+    with patch.object(InteractiveAgent, "_stdin_is_interactive", return_value=False):
+        with patch("builtins.input", side_effect=AssertionError("input() must not be called")) as mock_in:
+            with patch("minisweagent.agents.interactive.console.print"):
+                info = agent.run("Test non-interactive limit stop")
+
+    assert info["exit_status"] == "LimitsExceeded"
+    assert agent.n_calls == 1  # one model call happened, the next was blocked by the limit
+    mock_in.assert_not_called()
+
+
+def test_time_exceeded_never_prompts(model_factory):
+    """A wall-clock limit can't be lifted by raising step/cost limits, so it must
+    always stop cleanly -- even with an interactive terminal -- rather than prompt
+    (which would otherwise loop forever)."""
+    factory, config = model_factory
+    agent = InteractiveAgent(
+        model=factory([("Step 1", [{"command": "echo 'first step'"}])]),
+        env=LocalEnvironment(),
+        **{**config, "step_limit": 10, "cost_limit": 100.0, "wall_time_limit_seconds": 1, "mode": "yolo"},
+    )
+    agent._start_time = 0  # force the wall-clock budget to be already exhausted
+
+    with patch.object(InteractiveAgent, "_stdin_is_interactive", return_value=True):
+        with patch("builtins.input", side_effect=AssertionError("input() must not be called")) as mock_in:
+            with patch("minisweagent.agents.interactive.console.print"):
+                info = agent.run("Test time-exceeded clean stop")
+
+    assert info["exit_status"] == "TimeExceeded"
+    assert agent.n_calls == 0  # limit tripped before any model call
+    mock_in.assert_not_called()
 
 
 def test_continue_after_completion_with_new_task(model_factory):


### PR DESCRIPTION
## Problem

`InteractiveAgent.query()` handles a breached limit by prompting for new step and
cost limits via `input()`:

```python
except LimitsExceeded:
    ...
    self.config.step_limit = int(input("New step limit: "))
    self.config.cost_limit = float(input("New cost limit: "))
```

That assumes a human is at a terminal. In an **unattended run** there isn't one,
and the behaviour breaks in two ways:

1. **Crash on non-interactive stdin.** When stdin is redirected from `/dev/null`
   (CI, a batch harness, a sandbox — e.g. the way `pier` launches `mini-swe-agent
   --yolo` inside a container), `input()` raises `EOFError`. That uncaught
   exception propagates out of `run()`, so what should be a clean, trajectory-
   preserving budget stop instead crashes the whole trial and is recorded as an
   `EOFError` agent error rather than a normal `LimitsExceeded` exit.

   Note `--yolo` does **not** avoid this: it only suppresses *command*
   confirmation; the limit-extension prompt still fires.

2. **Infinite prompt loop on a time limit.** `TimeExceeded` subclasses
   `LimitsExceeded`, so it hits the same handler — but raising the step/cost
   limits can't satisfy a wall-clock budget. The next `query()` re-checks the
   clock and raises `TimeExceeded` again, re-prompting forever (even with a real
   terminal).

### Repro

```bash
mini --yolo -m <model> -t "<task>" -c agent.cost_limit=0.01 < /dev/null
# -> EOFError: EOF when reading a line   (run crashes instead of stopping at the limit)
```

## Fix

In `InteractiveAgent.query()`:

- Only prompt for new limits when an interactive terminal is actually available
  (`sys.stdin.isatty()`). Otherwise re-raise `LimitsExceeded`, so
  `DefaultAgent.run()` records a normal `LimitsExceeded` exit and saves the
  trajectory — the same clean stop a non-interactive agent already gets.
- Always re-raise `TimeExceeded` (it can't be lifted by raising step/cost limits),
  avoiding the infinite-prompt loop.

A small `_stdin_is_interactive()` helper also guards against `ValueError`/`OSError`
from a closed stdin.

Behaviour with a real terminal is unchanged: an interactive user still gets the
"New step limit / New cost limit" prompts on a step/cost breach exactly as before.

## Tests

- Add `test_limits_exceeded_non_interactive_stops_cleanly` — `--yolo` with no TTY:
  the run stops with a `LimitsExceeded` exit status and `input()` is never called.
- Add `test_time_exceeded_never_prompts` — even with a TTY, a wall-clock breach
  stops cleanly without prompting.
- The two existing limit-continuation tests already mock `input()` (i.e. they
  simulate a human at a terminal); they're updated to report an interactive TTY so
  they continue to exercise the prompt path.

`tests/agents/test_interactive.py` (108) and `tests/agents/test_default.py` (45)
pass; `ruff check` / `ruff format --check` clean.

Fixes #849.
