### PR TITLE
Handle reasoning truncation distinctly from a missing tool call

### DIFF
--- a/src/minisweagent/agents/default.py
+++ b/src/minisweagent/agents/default.py
@@ -12,7 +12,7 @@ from jinja2 import StrictUndefined, Template
 from pydantic import BaseModel
 
 from minisweagent import Environment, Model, __version__
-from minisweagent.exceptions import InterruptAgentFlow, LimitsExceeded, TimeExceeded
+from minisweagent.exceptions import FormatError, InterruptAgentFlow, LimitsExceeded, TimeExceeded
 from minisweagent.utils.serialize import recursive_merge
 
 
@@ -29,6 +29,10 @@ class AgentConfig(BaseModel):
     """Stop agent after exceeding (!) this cost."""
     wall_time_limit_seconds: int = 0
     """Stop agent after this many seconds of wall-clock time. 0 means no limit."""
+    max_consecutive_format_errors: int = 0
+    """Stop the agent after this many format errors in a row (e.g. repeated max_tokens truncations
+    that never produce a tool call). 0 means no limit. Guards against a model burning the whole
+    budget in a bounce loop; exits cleanly with exit_status=RepeatedFormatError."""
     output_path: Path | None = None
     """Save the trajectory to this path."""
 
@@ -44,6 +48,7 @@ class DefaultAgent:
         self.logger = logging.getLogger("agent")
         self.cost = 0.0
         self.n_calls = 0
+        self._consecutive_format_errors = 0
         self._start_time = time.time()
 
     def get_template_vars(self, **kwargs) -> dict:
@@ -93,11 +98,26 @@ class DefaultAgent:
         while True:
             try:
                 self.step()
+            except FormatError as e:
+                self.add_messages(*e.messages)
+                self._consecutive_format_errors += 1
+                if 0 < self.config.max_consecutive_format_errors <= self._consecutive_format_errors:
+                    # Too many no-tool-call / truncation turns in a row: stop cleanly instead of
+                    # looping until the budget is gone.
+                    self.add_messages(
+                        {
+                            "role": "exit",
+                            "content": "RepeatedFormatError",
+                            "extra": {"exit_status": "RepeatedFormatError", "submission": ""},
+                        }
+                    )
             except InterruptAgentFlow as e:
                 self.add_messages(*e.messages)
             except Exception as e:
                 self.handle_uncaught_exception(e)
                 raise
+            else:
+                self._consecutive_format_errors = 0  # a step completed without a format error
             finally:
                 self.save(self.config.output_path)
             if self.messages[-1].get("role") == "exit":

--- a/src/minisweagent/models/litellm_model.py
+++ b/src/minisweagent/models/litellm_model.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Any, Literal
 
 import litellm
+from jinja2 import StrictUndefined, Template
 from pydantic import BaseModel
 
 from minisweagent.exceptions import FormatError
@@ -37,6 +38,13 @@ class LitellmModelConfig(BaseModel):
     """Cost tracking mode for this model. Can be "default" or "ignore_errors" (ignore errors/missing cost info)"""
     format_error_template: str = "{{ error }}"
     """Template used when the LM's output is not in the expected format."""
+    truncation_error_template: str = (
+        "Your previous response reached the output token limit (finish_reason={{ finish_reason }}) "
+        "before you produced a tool call, so it was cut off. Respond more concisely and finish with "
+        "exactly one tool call. If you need to think more, do so briefly."
+    )
+    """Template used when a response is truncated at max_tokens before a tool call is produced.
+    Distinct from format_error_template so the model is told it was cut off (not that it forgot)."""
     observation_template: str = (
         "{% if output.exception_info %}<exception>{{output.exception_info}}</exception>\n{% endif %}"
         "<returncode>{{output.returncode}}</returncode>\n<output>\n{{output.output}}</output>"
@@ -94,6 +102,20 @@ class LitellmModel:
                 # model_dump failed (e.g. unserializable object); fall back to repr
                 # so the spec contract ("response MUST be persisted") holds unconditionally.
                 e.messages[0]["extra"]["response"] = repr(response)
+            # If the response was cut off at the output token limit before a tool call (common with
+            # reasoning models whose thinking can consume the whole max_tokens budget), tell the
+            # model it was truncated instead of the misleading default "no tool call found" retry.
+            if self._is_truncated(response):
+                finish_reason = response.choices[0].finish_reason
+                e.messages[0]["content"] = Template(
+                    self.config.truncation_error_template, undefined=StrictUndefined
+                ).render(finish_reason=finish_reason)
+                e.messages[0]["extra"]["truncated"] = True
+                logger.warning(
+                    "Model response truncated at the output token limit (finish_reason=%s) "
+                    "before a tool call -- consider raising max_tokens.",
+                    finish_reason,
+                )
             raise
         message = response.choices[0].message.model_dump()
         message["extra"] = {
@@ -128,6 +150,22 @@ class LitellmModel:
         """Parse tool calls from the response. Raises FormatError if unknown tool."""
         tool_calls = response.choices[0].message.tool_calls or []
         return parse_toolcall_actions(tool_calls, format_error_template=self.config.format_error_template)
+
+    @staticmethod
+    def _is_truncated(response) -> bool:
+        """Whether a no-tool-call response was cut off at the output token limit.
+
+        ``length`` means the completion was truncated mid-output; ``tool_calls`` with an empty
+        payload means it was cut right at the tool-call boundary. Both are budget truncations,
+        distinct from a model that simply ended its turn (``stop``/``end_turn``) without acting.
+        """
+        try:
+            choice = response.choices[0]
+            finish_reason = choice.finish_reason
+            has_tool_calls = bool(choice.message.tool_calls)
+        except (AttributeError, IndexError):
+            return False
+        return finish_reason == "length" or (finish_reason == "tool_calls" and not has_tool_calls)
 
     def format_message(self, **kwargs) -> dict:
         return expand_multimodal_content(kwargs, pattern=self.config.multimodal_regex)

--- a/tests/agents/test_default.py
+++ b/tests/agents/test_default.py
@@ -5,6 +5,7 @@ import yaml
 
 from minisweagent.agents.default import DefaultAgent
 from minisweagent.environments.local import LocalEnvironment
+from minisweagent.exceptions import FormatError
 from minisweagent.models.test_models import (
     DeterministicModel,
     DeterministicResponseAPIToolcallModel,
@@ -456,3 +457,55 @@ def test_empty_actions_handling(model_factory):
     assert info["exit_status"] == "Submitted"
     assert info["submission"] == "done\n"
     assert agent.n_calls == 2
+
+
+class _FlakyToolcallModel(DeterministicToolcallModel):
+    """Like DeterministicToolcallModel, but raises FormatError (as the real LitellmModel now does
+    on a truncated / no-tool-call turn) for any output marked {"_format_error": True}."""
+
+    def query(self, messages, **kwargs):
+        self.current_index += 1
+        output = self.config.outputs[self.current_index]
+        if output.get("_format_error"):
+            raise FormatError(
+                {
+                    "role": "user",
+                    "content": "No tool calls found in the response.",
+                    "extra": {"interrupt_type": "FormatError"},
+                }
+            )
+        return output
+
+
+def test_repeated_format_errors_terminate_cleanly(toolcall_config):
+    """With max_consecutive_format_errors set, a run that keeps producing no-tool-call / truncation
+    turns stops cleanly with exit_status=RepeatedFormatError instead of looping until the budget is
+    gone."""
+    outputs = [{"_format_error": True} for _ in range(5)]
+    agent = DefaultAgent(
+        model=_FlakyToolcallModel(outputs=outputs),
+        env=LocalEnvironment(),
+        **{**toolcall_config, "max_consecutive_format_errors": 2},
+    )
+    info = agent.run("Test repeated format errors")
+    assert info["exit_status"] == "RepeatedFormatError"
+    assert agent.n_calls == 2  # stopped at the 2nd consecutive error, didn't burn all 5
+
+
+def test_format_error_counter_resets_on_success(toolcall_config):
+    """A successful tool call between format errors resets the consecutive counter, so isolated
+    errors don't accumulate to the termination threshold."""
+    good = make_tc_model([("listing", [{"command": "echo hello"}])]).config.outputs[0]
+    submit = make_tc_model(
+        [("done", [{"command": "echo 'COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT'\necho ok"}])]
+    ).config.outputs[0]
+    # error, success (reset), error, submit -> never 2 in a row, so it must NOT terminate early.
+    outputs = [{"_format_error": True}, good, {"_format_error": True}, submit]
+    agent = DefaultAgent(
+        model=_FlakyToolcallModel(outputs=outputs),
+        env=LocalEnvironment(),
+        **{**toolcall_config, "max_consecutive_format_errors": 2},
+    )
+    info = agent.run("Test counter reset")
+    assert info["exit_status"] == "Submitted"
+    assert info["submission"] == "ok\n"

--- a/tests/models/test_litellm_model.py
+++ b/tests/models/test_litellm_model.py
@@ -62,6 +62,52 @@ class TestLitellmModel:
         with pytest.raises(FormatError):
             model.query([{"role": "user", "content": "test"}])
 
+    @patch("minisweagent.models.litellm_model.litellm.completion")
+    @patch("minisweagent.models.litellm_model.litellm.cost_calculator.completion_cost")
+    def test_truncation_finish_length_uses_truncation_message(self, mock_cost, mock_completion):
+        """finish_reason=length (cut off before a tool call) -> a truncation-aware retry, flagged."""
+        response = _mock_litellm_response(None)
+        response.choices[0].finish_reason = "length"
+        mock_completion.return_value = response
+        mock_cost.return_value = 0.001
+
+        with pytest.raises(FormatError) as exc:
+            LitellmModel(model_name="gpt-4").query([{"role": "user", "content": "test"}])
+
+        msg = exc.value.messages[0]
+        assert msg["extra"]["truncated"] is True
+        assert "cut off" in msg["content"] and "token limit" in msg["content"]
+        assert "No tool calls found" not in msg["content"]  # not the misleading "you forgot" message
+
+    @patch("minisweagent.models.litellm_model.litellm.completion")
+    @patch("minisweagent.models.litellm_model.litellm.cost_calculator.completion_cost")
+    def test_truncation_empty_toolcalls_payload_is_truncation(self, mock_cost, mock_completion):
+        """finish_reason=tool_calls but an empty payload = cut at the tool-call boundary."""
+        response = _mock_litellm_response(None)
+        response.choices[0].finish_reason = "tool_calls"
+        mock_completion.return_value = response
+        mock_cost.return_value = 0.001
+
+        with pytest.raises(FormatError) as exc:
+            LitellmModel(model_name="gpt-4").query([{"role": "user", "content": "test"}])
+        assert exc.value.messages[0]["extra"]["truncated"] is True
+        assert "cut off" in exc.value.messages[0]["content"]
+
+    @patch("minisweagent.models.litellm_model.litellm.completion")
+    @patch("minisweagent.models.litellm_model.litellm.cost_calculator.completion_cost")
+    def test_genuine_no_tool_call_is_not_truncation(self, mock_cost, mock_completion):
+        """finish_reason=stop with no tool call = the model really ended its turn without acting;
+        keep the normal 'no tool calls found' retry and do NOT flag truncation."""
+        response = _mock_litellm_response(None)
+        response.choices[0].finish_reason = "stop"
+        mock_completion.return_value = response
+        mock_cost.return_value = 0.001
+
+        with pytest.raises(FormatError) as exc:
+            LitellmModel(model_name="gpt-4").query([{"role": "user", "content": "test"}])
+        assert "truncated" not in exc.value.messages[0]["extra"]
+        assert "No tool calls found" in exc.value.messages[0]["content"]
+
     def test_format_observation_messages(self):
         model = LitellmModel(model_name="gpt-4", observation_template="{{ output.output }}")
         message = {"extra": {"actions": [{"command": "echo test", "tool_call_id": "call_1"}]}}


### PR DESCRIPTION
Builds on #821 (persist the full model response in `extra` on `FormatError`).

## Problem

When a tool-calling model returns a turn with **no tool call**, the retry tells it
*"No tool calls found in the response. Every response MUST include at least one tool call."*
But that message is often **wrong**: a reasoning model can spend its entire `max_tokens`
completion budget on `reasoning_content` and never reach the tool-call emission. The response
comes back with `finish_reason="length"` (cut mid-output) or `"tool_calls"` with an empty
payload (cut right at the boundary) — i.e. it was **truncated**, not that it "forgot." Telling a
truncated model to "include a tool call next time" is the wrong corrective signal, and if it
keeps happening the run burns its whole budget in a bounce loop.

### How we found it

Running MiniMax-M3 through `mini-swe-agent`, the no-tool-call turns on a hard task had a perfectly
clean signature once the response was inspectable (thanks to #821): **every** one had
`completion_tokens == max_tokens` exactly, with the budget consumed by `reasoning_content`, while
every *successful* turn finished comfortably under the cap. They were all `max_tokens` truncations
— raising the cap eliminated them.

## Changes

**1. Tell the model it was truncated, not that it forgot** (`LitellmModel`)
- When the `FormatError` response is a truncation (detected via `finish_reason`: `length`, or
  `tool_calls` with an empty payload), swap the retry for a **truncation-aware** message (new
  `truncation_error_template`), flag `extra.truncated=True`, and log a distinct warning suggesting
  a higher `max_tokens`. Genuine no-tool-call turns (`finish_reason=stop`) keep the existing
  message. The response is still persisted on the error exactly as #821 does.

**2. Bound a runaway bounce loop** (`DefaultAgent`)
- New `max_consecutive_format_errors` (default **0 = off**): after that many no-tool-call /
  truncation turns in a row, stop cleanly with `exit_status=RepeatedFormatError` instead of
  looping until the budget is gone. A successful tool call resets the counter.

## Why

- **Correct corrective signal:** a truncated model is told it was cut off (be concise), not that
  it omitted a tool call — the latter doesn't address the actual cause.
- **No silent budget burn:** an opt-in cap turns a truncation bounce loop into a clean, scoreable
  stop instead of consuming the whole time/cost budget. (We saw a single task spend dozens of
  turns this way.)
- **Actionable signal:** `extra.truncated` + the warning point operators straight at `max_tokens`,
  which is the real fix for reasoning models.

## Testing

- Model-level: `finish_reason=length` and empty-`tool_calls`-payload produce the truncation
  message + `extra.truncated`; a genuine `finish_reason=stop` no-tool-call keeps the original
  message and is not flagged (the response is still persisted on the error in all cases).
- Agent-level: `max_consecutive_format_errors` terminates with `exit_status=RepeatedFormatError`;
  a success between errors resets the counter.
- `tests/models/test_litellm_model.py`, `tests/agents/test_default.py`,
  `tests/agents/test_interactive.py` pass; `ruff check` / `ruff format --check` clean.

## Notes

- Non-breaking: the retry/bounce behaviour is unchanged except that a truncation now gets an
  accurate message; `max_consecutive_format_errors` defaults to off.
- Scope: `LitellmModel` (the common litellm path). The same truncation check could be added to the
  `openrouter` / response-API toolcall models in a follow-up.
