### PR TITLE
Add observer protocol for agent telemetry

### DIFF
--- a/src/minisweagent/__init__.py
+++ b/src/minisweagent/__init__.py
@@ -94,10 +94,13 @@ class AgentObserver(Protocol):
     observer callbacks as best-effort telemetry and continues if a callback
     raises.
 
-    In-agent failures are reported on the corresponding paired end callback
-    with ``exception=...`` (for example, ``on_model_end`` or
-    ``on_action_end``). If an uncaught exception fails the workflow as a whole,
-    ``on_error`` is emitted after the agent records its exit message.
+    In-agent control-flow interrupts are reported on the corresponding paired
+    end callback with ``interrupt=...``, ``interrupt_type=...``, and
+    ``status=...``. The messages carried by the interrupt are included as
+    ``interrupt_messages``. Genuine failures are reported on paired end
+    callbacks with ``exception=...`` and ``status="error"``. If an uncaught
+    exception fails the workflow as a whole, ``on_error`` is emitted after the
+    agent records its exit message.
     """
 
     def on_run_start(self, **kwargs) -> None: ...

--- a/src/minisweagent/__init__.py
+++ b/src/minisweagent/__init__.py
@@ -11,6 +11,7 @@ This file provides:
 __version__ = "2.3.0"
 
 import os
+from enum import Enum
 from pathlib import Path
 from typing import Any, Protocol
 
@@ -70,6 +71,53 @@ class Environment(Protocol):
     def serialize(self) -> dict: ...
 
 
+class AgentObserverEvent(str, Enum):
+    """Agent observer callback names used by agent implementations."""
+
+    RUN_START = "on_run_start"
+    RUN_END = "on_run_end"
+    STEP_START = "on_step_start"
+    STEP_END = "on_step_end"
+    MODEL_START = "on_model_start"
+    MODEL_END = "on_model_end"
+    ACTION_START = "on_action_start"
+    ACTION_END = "on_action_end"
+    INTERRUPT = "on_interrupt"
+    SUBMIT = "on_submit"
+    ERROR = "on_error"
+
+
+class AgentObserver(Protocol):
+    """Protocol for optional agent lifecycle observers.
+
+    Observers may implement any subset of these methods. Agent execution treats
+    observer callbacks as best-effort telemetry and continues if a callback
+    raises.
+    """
+
+    def on_run_start(self, **kwargs) -> None: ...
+
+    def on_run_end(self, **kwargs) -> None: ...
+
+    def on_step_start(self, **kwargs) -> None: ...
+
+    def on_step_end(self, **kwargs) -> None: ...
+
+    def on_model_start(self, **kwargs) -> None: ...
+
+    def on_model_end(self, **kwargs) -> None: ...
+
+    def on_action_start(self, **kwargs) -> None: ...
+
+    def on_action_end(self, **kwargs) -> None: ...
+
+    def on_interrupt(self, **kwargs) -> None: ...
+
+    def on_submit(self, **kwargs) -> None: ...
+
+    def on_error(self, **kwargs) -> None: ...
+
+
 class Agent(Protocol):
     """Protocol for agents."""
 
@@ -82,6 +130,8 @@ class Agent(Protocol):
 
 __all__ = [
     "Agent",
+    "AgentObserverEvent",
+    "AgentObserver",
     "Model",
     "Environment",
     "package_dir",

--- a/src/minisweagent/__init__.py
+++ b/src/minisweagent/__init__.py
@@ -93,6 +93,11 @@ class AgentObserver(Protocol):
     Observers may implement any subset of these methods. Agent execution treats
     observer callbacks as best-effort telemetry and continues if a callback
     raises.
+
+    In-agent failures are reported on the corresponding paired end callback
+    with ``exception=...`` (for example, ``on_model_end`` or
+    ``on_action_end``). If an uncaught exception fails the workflow as a whole,
+    ``on_error`` is emitted after the agent records its exit message.
     """
 
     def on_run_start(self, **kwargs) -> None: ...

--- a/src/minisweagent/agents/default.py
+++ b/src/minisweagent/agents/default.py
@@ -45,7 +45,12 @@ class DefaultAgent:
         observers: Iterable[AgentObserver] | None = None,
         **kwargs,
     ):
-        """See the `AgentConfig` class for permitted keyword arguments."""
+        """See the `AgentConfig` class for permitted keyword arguments.
+
+        `observer` is a convenience shortcut for passing a single observer.
+        Use `observers` when attaching multiple observers. If both are
+        supplied, `observer` is notified first.
+        """
         self.config = config_class(**kwargs)
         self.messages: list[dict] = []
         self.model = model
@@ -273,40 +278,48 @@ class DefaultAgent:
         )
         return message
 
-    def execute_actions(self, message: dict) -> list[dict]:
-        """Execute actions in message, add observation messages, return them."""
-        outputs = []
-        for action_index, action in enumerate(message.get("extra", {}).get("actions", [])):
-            observed_action = self._observer_action(action, message) if isinstance(action, dict) else action
-            self._notify(
-                AgentObserverEvent.ACTION_START,
-                action_index=action_index,
-                action=observed_action,
-                raw_action=action,
-                message=message,
-            )
-            try:
-                output = self.env.execute(action)
-            except Exception as e:
-                self._notify(
-                    AgentObserverEvent.ACTION_END,
-                    action_index=action_index,
-                    action=observed_action,
-                    raw_action=action,
-                    exception=e,
-                    message=message,
-                )
-                raise
-            outputs.append(output)
+    def _execute_action(self, message: dict, action_index: int, action: dict) -> dict:
+        """Execute one action and notify observers around the environment call."""
+        observed_action = self._observer_action(action, message) if isinstance(action, dict) else action
+        self._notify(
+            AgentObserverEvent.ACTION_START,
+            action_index=action_index,
+            action=observed_action,
+            raw_action=action,
+            message=message,
+        )
+        try:
+            output = self.env.execute(action)
+        except Exception as e:
             self._notify(
                 AgentObserverEvent.ACTION_END,
                 action_index=action_index,
                 action=observed_action,
                 raw_action=action,
-                output=output,
+                exception=e,
                 message=message,
             )
+            raise
+        self._notify(
+            AgentObserverEvent.ACTION_END,
+            action_index=action_index,
+            action=observed_action,
+            raw_action=action,
+            output=output,
+            message=message,
+        )
+        return output
+
+    def _add_observation_messages(self, message: dict, outputs: list[dict]) -> list[dict]:
         return self.add_messages(*self.model.format_observation_messages(message, outputs, self.get_template_vars()))
+
+    def execute_actions(self, message: dict) -> list[dict]:
+        """Execute actions in message, add observation messages, return them."""
+        outputs = [
+            self._execute_action(message, action_index, action)
+            for action_index, action in enumerate(message.get("extra", {}).get("actions", []))
+        ]
+        return self._add_observation_messages(message, outputs)
 
     def serialize(self, *extra_dicts) -> dict:
         """Serialize agent state to a json-compatible nested dictionary for saving."""

--- a/src/minisweagent/agents/default.py
+++ b/src/minisweagent/agents/default.py
@@ -6,12 +6,13 @@ import json
 import logging
 import time
 import traceback
+from collections.abc import Iterable
 from pathlib import Path
 
 from jinja2 import StrictUndefined, Template
 from pydantic import BaseModel
 
-from minisweagent import Environment, Model, __version__
+from minisweagent import AgentObserver, AgentObserverEvent, Environment, Model, __version__
 from minisweagent.exceptions import InterruptAgentFlow, LimitsExceeded, TimeExceeded
 from minisweagent.utils.serialize import recursive_merge
 
@@ -34,30 +35,43 @@ class AgentConfig(BaseModel):
 
 
 class DefaultAgent:
-    def __init__(self, model: Model, env: Environment, *, config_class: type = AgentConfig, observer=None, **kwargs):
+    def __init__(
+        self,
+        model: Model,
+        env: Environment,
+        *,
+        config_class: type = AgentConfig,
+        observer: AgentObserver | None = None,
+        observers: Iterable[AgentObserver] | None = None,
+        **kwargs,
+    ):
         """See the `AgentConfig` class for permitted keyword arguments."""
         self.config = config_class(**kwargs)
         self.messages: list[dict] = []
         self.model = model
         self.env = env
-        self.observer = observer
+        observer_list = []
+        if observer is not None:
+            observer_list.append(observer)
+        if observers is not None:
+            observer_list.extend(observers)
+        self.observers = tuple(observer_list)
         self.extra_template_vars = {}
         self.logger = logging.getLogger("agent")
         self.cost = 0.0
         self.n_calls = 0
         self._start_time = time.time()
 
-    def _notify(self, event_name: str, **payload) -> None:
+    def _notify(self, event_name: AgentObserverEvent, **payload) -> None:
         """Notify an optional observer without letting telemetry break agent execution."""
-        if self.observer is None:
-            return
-        handler = getattr(self.observer, event_name, None)
-        if handler is None:
-            return
-        try:
-            handler(agent=self, **payload)
-        except Exception:
-            self.logger.exception("Agent observer failed while handling %s", event_name)
+        for observer in self.observers:
+            handler = getattr(observer, event_name.value, None)
+            if handler is None:
+                continue
+            try:
+                handler(agent=self, **payload)
+            except Exception:
+                self.logger.exception("Agent observer failed while handling %s", event_name.value)
 
     @staticmethod
     def _get_tool_call_id(action: dict) -> str | None:
@@ -176,44 +190,44 @@ class DefaultAgent:
             self.model.format_message(role="system", content=self._render_template(self.config.system_template)),
             self.model.format_message(role="user", content=self._render_template(self.config.instance_template)),
         )
-        self._notify("on_run_start", task=task, kwargs=kwargs, messages=list(self.messages))
+        self._notify(AgentObserverEvent.RUN_START, task=task, kwargs=kwargs, messages=list(self.messages))
         while True:
             try:
                 self.step()
             except InterruptAgentFlow as e:
                 messages = self.add_messages(*e.messages)
-                self._notify("on_interrupt", exception=e, messages=messages)
+                self._notify(AgentObserverEvent.INTERRUPT, exception=e, messages=messages)
                 if messages and messages[-1].get("extra", {}).get("exit_status") == "Submitted":
                     self._notify(
-                        "on_submit",
+                        AgentObserverEvent.SUBMIT,
                         exception=e,
                         messages=messages,
                         submission=messages[-1].get("extra", {}).get("submission", ""),
                     )
             except Exception as e:
                 messages = self.handle_uncaught_exception(e)
-                self._notify("on_error", exception=e, messages=messages)
+                self._notify(AgentObserverEvent.ERROR, exception=e, messages=messages)
                 raise
             finally:
                 self.save(self.config.output_path)
             if self.messages[-1].get("role") == "exit":
                 break
         result = self.messages[-1].get("extra", {})
-        self._notify("on_run_end", result=result, messages=list(self.messages))
+        self._notify(AgentObserverEvent.RUN_END, result=result, messages=list(self.messages))
         return result
 
     def step(self) -> list[dict]:
         """Query the LM, execute actions."""
         step_index = self.n_calls + 1
-        self._notify("on_step_start", step_index=step_index, messages=list(self.messages))
+        self._notify(AgentObserverEvent.STEP_START, step_index=step_index, messages=list(self.messages))
         try:
             message = self.query()
             observations = self.execute_actions(message)
         except Exception as e:
-            self._notify("on_step_end", step_index=step_index, exception=e, messages=list(self.messages))
+            self._notify(AgentObserverEvent.STEP_END, step_index=step_index, exception=e, messages=list(self.messages))
             raise
         self._notify(
-            "on_step_end",
+            AgentObserverEvent.STEP_END,
             step_index=step_index,
             message=message,
             observations=observations,
@@ -241,16 +255,16 @@ class DefaultAgent:
             )
         self.n_calls += 1
         call_index = self.n_calls
-        self._notify("on_model_start", call_index=call_index, messages=list(self.messages))
+        self._notify(AgentObserverEvent.MODEL_START, call_index=call_index, messages=list(self.messages))
         try:
             message = self.model.query(self.messages)
         except Exception as e:
-            self._notify("on_model_end", call_index=call_index, exception=e, messages=list(self.messages))
+            self._notify(AgentObserverEvent.MODEL_END, call_index=call_index, exception=e, messages=list(self.messages))
             raise
         self.cost += message.get("extra", {}).get("cost", 0.0)
         self.add_messages(message)
         self._notify(
-            "on_model_end",
+            AgentObserverEvent.MODEL_END,
             call_index=call_index,
             message=message,
             cost=message.get("extra", {}).get("cost", 0.0),
@@ -265,7 +279,7 @@ class DefaultAgent:
         for action_index, action in enumerate(message.get("extra", {}).get("actions", [])):
             observed_action = self._observer_action(action, message) if isinstance(action, dict) else action
             self._notify(
-                "on_action_start",
+                AgentObserverEvent.ACTION_START,
                 action_index=action_index,
                 action=observed_action,
                 raw_action=action,
@@ -275,7 +289,7 @@ class DefaultAgent:
                 output = self.env.execute(action)
             except Exception as e:
                 self._notify(
-                    "on_action_end",
+                    AgentObserverEvent.ACTION_END,
                     action_index=action_index,
                     action=observed_action,
                     raw_action=action,
@@ -285,7 +299,7 @@ class DefaultAgent:
                 raise
             outputs.append(output)
             self._notify(
-                "on_action_end",
+                AgentObserverEvent.ACTION_END,
                 action_index=action_index,
                 action=observed_action,
                 raw_action=action,

--- a/src/minisweagent/agents/default.py
+++ b/src/minisweagent/agents/default.py
@@ -79,6 +79,15 @@ class DefaultAgent:
                 self.logger.exception("Agent observer failed while handling %s", event_name.value)
 
     @staticmethod
+    def _interrupt_payload(interrupt: InterruptAgentFlow) -> dict:
+        return {
+            "interrupt": interrupt,
+            "interrupt_type": type(interrupt).__name__,
+            "interrupt_messages": list(interrupt.messages),
+            "status": "interrupted",
+        }
+
+    @staticmethod
     def _get_tool_call_id(action: dict) -> str | None:
         for key in ("id", "tool_call_id", "call_id", "tool_use_id"):
             if action.get(key):
@@ -201,11 +210,11 @@ class DefaultAgent:
                 self.step()
             except InterruptAgentFlow as e:
                 messages = self.add_messages(*e.messages)
-                self._notify(AgentObserverEvent.INTERRUPT, exception=e, messages=messages)
+                self._notify(AgentObserverEvent.INTERRUPT, **self._interrupt_payload(e), messages=messages)
                 if messages and messages[-1].get("extra", {}).get("exit_status") == "Submitted":
                     self._notify(
                         AgentObserverEvent.SUBMIT,
-                        exception=e,
+                        **self._interrupt_payload(e),
                         messages=messages,
                         submission=messages[-1].get("extra", {}).get("submission", ""),
                     )
@@ -228,8 +237,22 @@ class DefaultAgent:
         try:
             message = self.query()
             observations = self.execute_actions(message)
+        except InterruptAgentFlow as e:
+            self._notify(
+                AgentObserverEvent.STEP_END,
+                step_index=step_index,
+                **self._interrupt_payload(e),
+                messages=list(self.messages),
+            )
+            raise
         except Exception as e:
-            self._notify(AgentObserverEvent.STEP_END, step_index=step_index, exception=e, messages=list(self.messages))
+            self._notify(
+                AgentObserverEvent.STEP_END,
+                step_index=step_index,
+                exception=e,
+                status="error",
+                messages=list(self.messages),
+            )
             raise
         self._notify(
             AgentObserverEvent.STEP_END,
@@ -263,8 +286,22 @@ class DefaultAgent:
         self._notify(AgentObserverEvent.MODEL_START, call_index=call_index, messages=list(self.messages))
         try:
             message = self.model.query(self.messages)
+        except InterruptAgentFlow as e:
+            self._notify(
+                AgentObserverEvent.MODEL_END,
+                call_index=call_index,
+                **self._interrupt_payload(e),
+                messages=list(self.messages),
+            )
+            raise
         except Exception as e:
-            self._notify(AgentObserverEvent.MODEL_END, call_index=call_index, exception=e, messages=list(self.messages))
+            self._notify(
+                AgentObserverEvent.MODEL_END,
+                call_index=call_index,
+                exception=e,
+                status="error",
+                messages=list(self.messages),
+            )
             raise
         self.cost += message.get("extra", {}).get("cost", 0.0)
         self.add_messages(message)
@@ -290,6 +327,16 @@ class DefaultAgent:
         )
         try:
             output = self.env.execute(action)
+        except InterruptAgentFlow as e:
+            self._notify(
+                AgentObserverEvent.ACTION_END,
+                action_index=action_index,
+                action=observed_action,
+                raw_action=action,
+                **self._interrupt_payload(e),
+                message=message,
+            )
+            raise
         except Exception as e:
             self._notify(
                 AgentObserverEvent.ACTION_END,
@@ -297,6 +344,7 @@ class DefaultAgent:
                 action=observed_action,
                 raw_action=action,
                 exception=e,
+                status="error",
                 message=message,
             )
             raise

--- a/src/minisweagent/agents/default.py
+++ b/src/minisweagent/agents/default.py
@@ -34,17 +34,103 @@ class AgentConfig(BaseModel):
 
 
 class DefaultAgent:
-    def __init__(self, model: Model, env: Environment, *, config_class: type = AgentConfig, **kwargs):
+    def __init__(self, model: Model, env: Environment, *, config_class: type = AgentConfig, observer=None, **kwargs):
         """See the `AgentConfig` class for permitted keyword arguments."""
         self.config = config_class(**kwargs)
         self.messages: list[dict] = []
         self.model = model
         self.env = env
+        self.observer = observer
         self.extra_template_vars = {}
         self.logger = logging.getLogger("agent")
         self.cost = 0.0
         self.n_calls = 0
         self._start_time = time.time()
+
+    def _notify(self, event_name: str, **payload) -> None:
+        """Notify an optional observer without letting telemetry break agent execution."""
+        if self.observer is None:
+            return
+        handler = getattr(self.observer, event_name, None)
+        if handler is None:
+            return
+        try:
+            handler(agent=self, **payload)
+        except Exception:
+            self.logger.exception("Agent observer failed while handling %s", event_name)
+
+    @staticmethod
+    def _get_tool_call_id(action: dict) -> str | None:
+        for key in ("id", "tool_call_id", "call_id", "tool_use_id"):
+            if action.get(key):
+                return str(action[key])
+        return None
+
+    @staticmethod
+    def _tool_call_id(tool_call: dict) -> str | None:
+        return tool_call.get("id") or tool_call.get("call_id")
+
+    @staticmethod
+    def _tool_call_name(tool_call: dict) -> str | None:
+        function = tool_call.get("function")
+        if isinstance(function, dict) and function.get("name"):
+            return str(function["name"])
+        if tool_call.get("name"):
+            return str(tool_call["name"])
+        return None
+
+    @staticmethod
+    def _tool_call_arguments(tool_call: dict) -> dict | None:
+        function = tool_call.get("function")
+        arguments = function.get("arguments") if isinstance(function, dict) else tool_call.get("arguments")
+        if isinstance(arguments, dict):
+            return arguments
+        if isinstance(arguments, str):
+            try:
+                parsed = json.loads(arguments)
+            except json.JSONDecodeError:
+                return {"raw": arguments}
+            if isinstance(parsed, dict):
+                return parsed
+            return {"value": parsed}
+        return None
+
+    @staticmethod
+    def _message_tool_calls(message: dict) -> list[dict]:
+        tool_calls = []
+        for tool_call in message.get("tool_calls", []) or []:
+            if isinstance(tool_call, dict):
+                tool_calls.append(tool_call)
+        for item in message.get("output", []) or []:
+            if isinstance(item, dict) and item.get("type") == "function_call":
+                tool_calls.append(item)
+        return tool_calls
+
+    def _observer_action(self, action: dict, message: dict) -> dict:
+        """Return a stable action payload for observers without changing execution input."""
+        observed_action = dict(action)
+        tool_call_id = self._get_tool_call_id(observed_action)
+        tool_call = None
+        for candidate in self._message_tool_calls(message):
+            if tool_call_id and self._tool_call_id(candidate) == tool_call_id:
+                tool_call = candidate
+                break
+
+        if tool_call_id:
+            observed_action.setdefault("id", tool_call_id)
+            observed_action.setdefault("tool_call_id", tool_call_id)
+        if tool_call is not None:
+            if name := self._tool_call_name(tool_call):
+                observed_action.setdefault("name", name)
+            if arguments := self._tool_call_arguments(tool_call):
+                observed_action.setdefault("arguments", arguments)
+            observed_action.setdefault("kind", "tool_call")
+
+        if "arguments" not in observed_action and "command" in observed_action:
+            observed_action["arguments"] = {"command": observed_action["command"]}
+        observed_action.setdefault("name", "action.exec")
+        observed_action.setdefault("kind", "action")
+        return observed_action
 
     def get_template_vars(self, **kwargs) -> dict:
         return recursive_merge(
@@ -90,23 +176,50 @@ class DefaultAgent:
             self.model.format_message(role="system", content=self._render_template(self.config.system_template)),
             self.model.format_message(role="user", content=self._render_template(self.config.instance_template)),
         )
+        self._notify("on_run_start", task=task, kwargs=kwargs, messages=list(self.messages))
         while True:
             try:
                 self.step()
             except InterruptAgentFlow as e:
-                self.add_messages(*e.messages)
+                messages = self.add_messages(*e.messages)
+                self._notify("on_interrupt", exception=e, messages=messages)
+                if messages and messages[-1].get("extra", {}).get("exit_status") == "Submitted":
+                    self._notify(
+                        "on_submit",
+                        exception=e,
+                        messages=messages,
+                        submission=messages[-1].get("extra", {}).get("submission", ""),
+                    )
             except Exception as e:
-                self.handle_uncaught_exception(e)
+                messages = self.handle_uncaught_exception(e)
+                self._notify("on_error", exception=e, messages=messages)
                 raise
             finally:
                 self.save(self.config.output_path)
             if self.messages[-1].get("role") == "exit":
                 break
-        return self.messages[-1].get("extra", {})
+        result = self.messages[-1].get("extra", {})
+        self._notify("on_run_end", result=result, messages=list(self.messages))
+        return result
 
     def step(self) -> list[dict]:
         """Query the LM, execute actions."""
-        return self.execute_actions(self.query())
+        step_index = self.n_calls + 1
+        self._notify("on_step_start", step_index=step_index, messages=list(self.messages))
+        try:
+            message = self.query()
+            observations = self.execute_actions(message)
+        except Exception as e:
+            self._notify("on_step_end", step_index=step_index, exception=e, messages=list(self.messages))
+            raise
+        self._notify(
+            "on_step_end",
+            step_index=step_index,
+            message=message,
+            observations=observations,
+            messages=list(self.messages),
+        )
+        return observations
 
     def query(self) -> dict:
         """Query the model and return model messages. Override to add hooks."""
@@ -127,14 +240,58 @@ class DefaultAgent:
                 }
             )
         self.n_calls += 1
-        message = self.model.query(self.messages)
+        call_index = self.n_calls
+        self._notify("on_model_start", call_index=call_index, messages=list(self.messages))
+        try:
+            message = self.model.query(self.messages)
+        except Exception as e:
+            self._notify("on_model_end", call_index=call_index, exception=e, messages=list(self.messages))
+            raise
         self.cost += message.get("extra", {}).get("cost", 0.0)
         self.add_messages(message)
+        self._notify(
+            "on_model_end",
+            call_index=call_index,
+            message=message,
+            cost=message.get("extra", {}).get("cost", 0.0),
+            total_cost=self.cost,
+            messages=list(self.messages),
+        )
         return message
 
     def execute_actions(self, message: dict) -> list[dict]:
         """Execute actions in message, add observation messages, return them."""
-        outputs = [self.env.execute(action) for action in message.get("extra", {}).get("actions", [])]
+        outputs = []
+        for action_index, action in enumerate(message.get("extra", {}).get("actions", [])):
+            observed_action = self._observer_action(action, message) if isinstance(action, dict) else action
+            self._notify(
+                "on_action_start",
+                action_index=action_index,
+                action=observed_action,
+                raw_action=action,
+                message=message,
+            )
+            try:
+                output = self.env.execute(action)
+            except Exception as e:
+                self._notify(
+                    "on_action_end",
+                    action_index=action_index,
+                    action=observed_action,
+                    raw_action=action,
+                    exception=e,
+                    message=message,
+                )
+                raise
+            outputs.append(output)
+            self._notify(
+                "on_action_end",
+                action_index=action_index,
+                action=observed_action,
+                raw_action=action,
+                output=output,
+                message=message,
+            )
         return self.add_messages(*self.model.format_observation_messages(message, outputs, self.get_template_vars()))
 
     def serialize(self, *extra_dicts) -> dict:

--- a/src/minisweagent/agents/interactive.py
+++ b/src/minisweagent/agents/interactive.py
@@ -102,8 +102,8 @@ class InteractiveAgent(DefaultAgent):
         outputs = []
         try:
             self._ask_confirmation_or_interrupt(commands)
-            for action in actions:
-                outputs.append(self.env.execute(action))
+            for action_index, action in enumerate(actions):
+                outputs.append(self._execute_action(message, action_index, action))
         except Submitted as e:
             self._check_for_new_task_or_submit(e)
         finally:

--- a/tests/agents/test_default.py
+++ b/tests/agents/test_default.py
@@ -203,6 +203,36 @@ def test_observer_receives_lifecycle_events(default_config):
     assert submit_payload["submission"] == "done\n"
 
 
+def test_multiple_observers_are_isolated(default_config):
+    class FailingObserver:
+        def on_action_start(self, **kwargs):
+            raise RuntimeError("observer failed")
+
+    first = RecordingObserver()
+    second = RecordingObserver()
+    agent = DefaultAgent(
+        model=make_text_model(
+            [
+                ("Inspect", [{"command": "echo 'hello'"}]),
+                ("Finish", [{"command": "echo 'COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT'\necho 'done'"}]),
+            ]
+        ),
+        env=LocalEnvironment(),
+        observers=[first, FailingObserver(), second],
+        **default_config,
+    )
+
+    info = agent.run("Use multiple observer hooks")
+
+    assert info["exit_status"] == "Submitted"
+    first_event_names = [name for name, _payload in first.events]
+    second_event_names = [name for name, _payload in second.events]
+    assert first_event_names.count("on_action_start") == 2
+    assert second_event_names.count("on_action_start") == 2
+    assert first_event_names[-1] == "on_run_end"
+    assert second_event_names[-1] == "on_run_end"
+
+
 def test_observer_receives_uncaught_errors(default_config):
     class ExplodingModel(DeterministicModel):
         def query(self, messages: list[dict[str, str]], **kwargs) -> dict:

--- a/tests/agents/test_default.py
+++ b/tests/agents/test_default.py
@@ -233,6 +233,45 @@ def test_multiple_observers_are_isolated(default_config):
     assert second_event_names[-1] == "on_run_end"
 
 
+def test_single_observer_shortcut_is_notified_before_observers(default_config):
+    order = []
+
+    class OrderedObserver(RecordingObserver):
+        def __init__(self, label: str):
+            super().__init__()
+            self.label = label
+
+        def __getattr__(self, name):
+            record = super().__getattr__(name)
+
+            def ordered_record(**payload):
+                order.append((name, self.label))
+                record(**payload)
+
+            return ordered_record
+
+    first = OrderedObserver("shortcut")
+    second = OrderedObserver("list")
+    agent = DefaultAgent(
+        model=make_text_model(
+            [
+                ("Finish", [{"command": "echo 'COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT'\necho 'done'"}]),
+            ]
+        ),
+        env=LocalEnvironment(),
+        observer=first,
+        observers=[second],
+        **default_config,
+    )
+
+    info = agent.run("Use observer shortcut")
+
+    assert info["exit_status"] == "Submitted"
+    assert [name for name, _payload in first.events] == [name for name, _payload in second.events]
+    assert first.events[0][0] == "on_run_start"
+    assert order[:2] == [("on_run_start", "shortcut"), ("on_run_start", "list")]
+
+
 def test_observer_receives_uncaught_errors(default_config):
     class ExplodingModel(DeterministicModel):
         def query(self, messages: list[dict[str, str]], **kwargs) -> dict:

--- a/tests/agents/test_default.py
+++ b/tests/agents/test_default.py
@@ -112,6 +112,20 @@ def make_response_api_model(
     return DeterministicResponseAPIToolcallModel(outputs=outputs, **kwargs)
 
 
+class RecordingObserver:
+    def __init__(self):
+        self.events = []
+
+    def __getattr__(self, name):
+        if not name.startswith("on_"):
+            raise AttributeError(name)
+
+        def record(**payload):
+            self.events.append((name, payload))
+
+        return record
+
+
 @pytest.fixture(params=["text", "toolcall", "response_api"])
 def model_factory(request, default_config, toolcall_config):
     """Parametrized fixture that returns (factory_fn, config) for all three model types."""
@@ -147,6 +161,99 @@ def test_successful_completion(model_factory):
     assert info["exit_status"] == "Submitted"
     assert info["submission"] == "Task completed successfully\n"
     assert agent.n_calls == 2
+
+
+def test_observer_receives_lifecycle_events(default_config):
+    observer = RecordingObserver()
+    agent = DefaultAgent(
+        model=make_text_model(
+            [
+                ("Inspect", [{"command": "echo 'hello'"}]),
+                ("Finish", [{"command": "echo 'COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT'\necho 'done'"}]),
+            ]
+        ),
+        env=LocalEnvironment(),
+        observer=observer,
+        **default_config,
+    )
+
+    info = agent.run("Use observer hooks")
+    event_names = [name for name, _payload in observer.events]
+
+    assert info["exit_status"] == "Submitted"
+    assert event_names[0] == "on_run_start"
+    assert event_names.count("on_step_start") == 2
+    assert event_names.count("on_step_end") == 2
+    assert event_names.count("on_model_start") == 2
+    assert event_names.count("on_model_end") == 2
+    assert event_names.count("on_action_start") == 2
+    assert event_names.count("on_action_end") == 2
+    assert "on_interrupt" in event_names
+    assert "on_submit" in event_names
+    assert event_names[-1] == "on_run_end"
+
+    first_action_end = next(payload for name, payload in observer.events if name == "on_action_end")
+    assert first_action_end["action"]["name"] == "action.exec"
+    assert first_action_end["action"]["arguments"] == {"command": "echo 'hello'"}
+    assert first_action_end["raw_action"] == {"command": "echo 'hello'"}
+    assert first_action_end["output"]["returncode"] == 0
+    assert "hello" in first_action_end["output"]["output"]
+
+    submit_payload = next(payload for name, payload in observer.events if name == "on_submit")
+    assert submit_payload["submission"] == "done\n"
+
+
+def test_observer_receives_uncaught_errors(default_config):
+    class ExplodingModel(DeterministicModel):
+        def query(self, messages: list[dict[str, str]], **kwargs) -> dict:
+            raise RuntimeError("boom")
+
+    observer = RecordingObserver()
+    agent = DefaultAgent(
+        model=ExplodingModel(outputs=[]),
+        env=LocalEnvironment(),
+        observer=observer,
+        **default_config,
+    )
+
+    with pytest.raises(RuntimeError, match="boom"):
+        agent.run("Raise from model")
+
+    event_names = [name for name, _payload in observer.events]
+    assert "on_model_end" in event_names
+    assert "on_step_end" in event_names
+    assert "on_error" in event_names
+    error_payload = next(payload for name, payload in observer.events if name == "on_error")
+    assert isinstance(error_payload["exception"], RuntimeError)
+
+
+@pytest.mark.parametrize("factory", [make_tc_model, make_response_api_model])
+def test_observer_receives_normalized_tool_call_actions(factory, toolcall_config):
+    observer = RecordingObserver()
+    agent = DefaultAgent(
+        model=factory([("Inspect", [{"command": "echo 'hello'"}])]),
+        env=LocalEnvironment(),
+        observer=observer,
+        **toolcall_config,
+    )
+    agent.add_messages(
+        agent.model.format_message(role="system", content="system"),
+        agent.model.format_message(role="user", content="task"),
+    )
+
+    agent.step()
+
+    action_start = next(payload for name, payload in observer.events if name == "on_action_start")
+    action_end = next(payload for name, payload in observer.events if name == "on_action_end")
+
+    assert action_start["action"]["name"] == "bash"
+    assert action_start["action"]["arguments"] == {"command": "echo 'hello'"}
+    assert action_start["action"]["kind"] == "tool_call"
+    assert action_start["action"]["id"] == action_start["raw_action"]["tool_call_id"]
+    assert action_start["action"]["tool_call_id"] == action_start["raw_action"]["tool_call_id"]
+    assert action_start["raw_action"] == {"command": "echo 'hello'", "tool_call_id": action_start["action"]["id"]}
+    assert action_end["action"] == action_start["action"]
+    assert action_end["raw_action"] == action_start["raw_action"]
 
 
 def test_step_limit_enforcement(model_factory):

--- a/tests/agents/test_default.py
+++ b/tests/agents/test_default.py
@@ -5,6 +5,7 @@ import yaml
 
 from minisweagent.agents.default import DefaultAgent
 from minisweagent.environments.local import LocalEnvironment
+from minisweagent.exceptions import FormatError
 from minisweagent.models.test_models import (
     DeterministicModel,
     DeterministicResponseAPIToolcallModel,
@@ -199,8 +200,29 @@ def test_observer_receives_lifecycle_events(default_config):
     assert first_action_end["output"]["returncode"] == 0
     assert "hello" in first_action_end["output"]["output"]
 
+    action_ends = [payload for name, payload in observer.events if name == "on_action_end"]
+    submit_action_end = action_ends[-1]
+    assert submit_action_end["status"] == "interrupted"
+    assert submit_action_end["interrupt_type"] == "Submitted"
+    assert submit_action_end["interrupt_messages"][0]["extra"]["exit_status"] == "Submitted"
+    assert "interrupt" in submit_action_end
+    assert "exception" not in submit_action_end
+
+    step_ends = [payload for name, payload in observer.events if name == "on_step_end"]
+    submit_step_end = step_ends[-1]
+    assert submit_step_end["status"] == "interrupted"
+    assert submit_step_end["interrupt_type"] == "Submitted"
+    assert submit_step_end["interrupt_messages"][0]["extra"]["exit_status"] == "Submitted"
+    assert "interrupt" in submit_step_end
+    assert "exception" not in submit_step_end
+
     submit_payload = next(payload for name, payload in observer.events if name == "on_submit")
     assert submit_payload["submission"] == "done\n"
+    assert submit_payload["status"] == "interrupted"
+    assert submit_payload["interrupt_type"] == "Submitted"
+    assert submit_payload["interrupt_messages"][0]["extra"]["exit_status"] == "Submitted"
+    assert "interrupt" in submit_payload
+    assert "exception" not in submit_payload
 
 
 def test_multiple_observers_are_isolated(default_config):
@@ -294,6 +316,36 @@ def test_observer_receives_uncaught_errors(default_config):
     assert "on_error" in event_names
     error_payload = next(payload for name, payload in observer.events if name == "on_error")
     assert isinstance(error_payload["exception"], RuntimeError)
+
+
+def test_observer_reports_model_interrupts_separately_from_errors(default_config):
+    class FormattingModel(DeterministicModel):
+        def query(self, messages: list[dict[str, str]], **kwargs) -> dict:
+            raise FormatError({"role": "user", "content": "bad format", "extra": {"interrupt_type": "FormatError"}})
+
+    observer = RecordingObserver()
+    agent = DefaultAgent(
+        model=FormattingModel(outputs=[]),
+        env=LocalEnvironment(),
+        observer=observer,
+        **default_config,
+    )
+    agent.add_messages(
+        agent.model.format_message(role="system", content="system"),
+        agent.model.format_message(role="user", content="task"),
+    )
+
+    with pytest.raises(FormatError):
+        agent.query()
+
+    model_end = next(payload for name, payload in observer.events if name == "on_model_end")
+    assert model_end["status"] == "interrupted"
+    assert model_end["interrupt_type"] == "FormatError"
+    assert model_end["interrupt_messages"] == [
+        {"role": "user", "content": "bad format", "extra": {"interrupt_type": "FormatError"}}
+    ]
+    assert "interrupt" in model_end
+    assert "exception" not in model_end
 
 
 @pytest.mark.parametrize("factory", [make_tc_model, make_response_api_model])

--- a/tests/agents/test_interactive.py
+++ b/tests/agents/test_interactive.py
@@ -48,6 +48,20 @@ def get_text(msg: dict) -> str:
     return ""
 
 
+class RecordingObserver:
+    def __init__(self):
+        self.events = []
+
+    def __getattr__(self, name):
+        if not name.startswith("on_"):
+            raise AttributeError(name)
+
+        def record(**payload):
+            self.events.append((name, payload))
+
+        return record
+
+
 # --- Model factory functions ---
 
 
@@ -148,6 +162,36 @@ def test_successful_completion_with_confirmation(model_factory):
         assert info["exit_status"] == "Submitted"
         assert info["submission"] == "completed\n"
         assert agent.n_calls == 1
+
+
+def test_observer_receives_action_events_with_confirmation(model_factory):
+    """Test interactive action execution preserves observer callbacks."""
+    factory, config = model_factory
+    observer = RecordingObserver()
+    with mock_prompts(["", "", ""]):  # Confirm both actions, then no new task
+        agent = InteractiveAgent(
+            model=factory(
+                [
+                    ("Inspect", [{"command": "echo hello"}]),
+                    ("Finishing", [{"command": "echo 'COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT'\necho 'completed'"}]),
+                ]
+            ),
+            env=LocalEnvironment(),
+            observer=observer,
+            **config,
+        )
+
+        info = agent.run("Test observer action hooks")
+
+    event_names = [name for name, _payload in observer.events]
+    assert info["exit_status"] == "Submitted"
+    assert event_names.count("on_action_start") == 2
+    assert event_names.count("on_action_end") == 2
+
+    action_end = next(payload for name, payload in observer.events if name == "on_action_end")
+    assert action_end["action"]["arguments"] == {"command": "echo hello"}
+    assert action_end["output"]["returncode"] == 0
+    assert "hello" in action_end["output"]["output"]
 
 
 def test_action_rejection_and_recovery(model_factory):


### PR DESCRIPTION
## Summary

This draft adds a small, optional observer surface to Mini SWE Agent so third-party observability middleware can observe faithful run, step, model, and action execution boundaries without parsing saved trajectories.

The API is middleware-neutral and does not add any dependency on NeMo Relay, OpenTelemetry, Phoenix, or another exporter.

Related issue: #853

The PR is intended for **_discussion only_**.

## Changes

- Add `AgentObserverEvent` and `AgentObserver` protocol definitions.
- Allow `DefaultAgent` to accept `observer=` and `observers=`.
- Emit best-effort observer callbacks for run, step, model, action, interrupt, submit, and error paths.
- Expose structured action metadata for observer callbacks while preserving the raw action passed to the environment.
- Isolate observer failures so telemetry cannot fail the agent run or block other observers.

## Validation

- `UV_CACHE_DIR=/home/anuradhak/projects/nat/.tmp/uv-cache uv run pytest tests/agents -q` -> 181 passed

## Notes

This is intended as a reference implementation for discussing minimal observability hooks. The implementation deliberately keeps export formats out of Mini SWE Agent; integrations such as NVIDIA NeMo Relay can translate these hooks into ATOF/ATIF externally.