### PR TITLE
Fix(swebench): source ~/.bashrc via BASH_ENV to activate testbed env

### DIFF
--- a/src/minisweagent/config/benchmarks/swebench.yaml
+++ b/src/minisweagent/config/benchmarks/swebench.yaml
@@ -122,6 +122,9 @@ environment:
     LESS: -R
     PIP_PROGRESS_BAR: "off"
     TQDM_DISABLE: "1"
+    # bash -c is non-login so it won't source ~/.bashrc; point BASH_ENV at it so the
+    # image's `conda activate testbed` runs (else commands use the base env, no testbed).
+    BASH_ENV: /root/.bashrc
   environment_class: docker
 
 model:


### PR DESCRIPTION
## Problem

`swebench.yaml` runs every agent command through a non-interactive, non-login
`bash -c` (`interpreter: ["bash", "-c"]`, added in #724 so that the login
shell's `/etc/profile` would not reset `$PATH` and drop image-baked toolchains
such as `cargo` on the multilingual Rust images — see #495).

SWE-bench **Python** images, however, activate their `testbed` conda env via
`conda activate testbed` in `~/.bashrc`. A non-interactive `bash -c` never
sources `~/.bashrc`, so since #724 every command on Python images has run in
the **base** conda env (Python 3.11, no `pytest`, no project deps) instead of
`testbed`. The agent could not import the project under test or run its own
tests — its reproduction loop was silently broken.

This is hard to notice manually: `docker exec -it <cid> bash` is an
*interactive* shell, which **does** source `~/.bashrc`, so testbed looks fine
when you poke at the container by hand — only the agent's `bash -c` is affected.

## Root cause: two image families with conflicting shell needs

| image family | toolchain activated by | needs |
|---|---|---|
| Python | `~/.bashrc` (`conda activate testbed`) | `~/.bashrc` sourced |
| Rust / multilingual | image `ENV` `PATH` (`/usr/local/cargo/bin`) | `/etc/profile` **not** sourced (it resets PATH) |

#724 chose `bash -c` to satisfy the Rust case, which broke the Python case.
Reverting to `bash -lc` would re-break the Rust case (#495).

## Fix

```yaml
environment:
  env:
    BASH_ENV: /root/.bashrc
```

A non-interactive bash sources the file named by `$BASH_ENV` at startup, so
`~/.bashrc` runs (activating `testbed`) **without** sourcing `/etc/profile`
(which is what reset PATH and broke `cargo`). It is the orthogonal fix that
satisfies both families.

**Scope:** only `swebench.yaml` (the default, most-used config). The same line
applies to `swebench_backticks.yaml` / `swebench_xml.yaml` and could be
extended; `swebench_modal.yaml` uses the `swerex_modal` environment whose env
injection is unverified, so it is intentionally left out.

## Verification

### Container-level (model-agnostic, reproducible)

`docker exec -w /testbed [-e BASH_ENV=/root/.bashrc] $CID bash -c '...'`:

| instance | without BASH_ENV | with BASH_ENV |
|---|---|---|
| astropy-12907 | base python; `import astropy` → Traceback; no pytest; tests can't run | testbed python; `import astropy` ok; `pytest test_separable.py` → **11 passed** |
| django-11119 | `tests/runtests.py` → `No module named django` | runtests → **OK** |
| Rust axum-1934 (multilingual) | `cargo` on PATH | `cargo` **still** on PATH (no regression) |

### Impact on a real agent run (deepseek-v4-pro, before → after)

Tool-call format, same two instances:

| instance | phase | steps | testbed active | env_broken cmds | env-repair cmds | verdict |
|---|---|---|---|---|---|---|
| astropy-12907 | before | 39 | no (base) | 10 | 8 | informal-verify only |
| astropy-12907 | after  | **22** | **yes** | **1** | **0** | **ran real tests** |
| django-11119 | before | 23 | no (base) | 5 | 6 | ran real tests |
| django-11119 | after  | 21 | **yes** | 4 | **1** | ran real tests |

Without the fix the agent burned 8 steps rebuilding the env by hand
(`pip install -e .`, erfa/numpy/pytest, `setup.py build_ext`) before it could
verify anything; with the fix testbed is active immediately, so it drops the
env-repair work, runs the real suite, and finishes in fewer steps.

### Impact at scale (baseline, deepseek-v4-pro, SWE-bench Verified first 100)

Across the 73 resolved instances **without** the fix, only the trajectory was
inspected (no eval needed): 47 eventually ran the real suite (all via manual
env workarounds), 17 fell back to informal `python -c` checks after the suite
broke on the env, 7 only ever hit the broken env, and 2 submitted with no
verification. The dominant harm was not blind submission but **verification
downgrade + wasted env-repair steps** — exactly what this fix removes.

## Tests

This is a one-line config-value change, so no new test is added — matching the
precedent of #724, which introduced `interpreter: ["bash", "-c"]` across the
swebench configs without tests. The existing `pytest tests/config` and the
docker environment tests pass; `pre-commit` is clean.

Refs #495, #724