### PR TITLE
fix: kill local process group on timeout

### DIFF
--- a/src/minisweagent/environments/local.py
+++ b/src/minisweagent/environments/local.py
@@ -1,5 +1,6 @@
 import os
 import platform
+import signal
 import subprocess
 from typing import Any
 
@@ -24,18 +25,23 @@ class LocalEnvironment:
         """Execute a command in the local environment and return the result as a dict."""
         command = action.get("command", "")
         cwd = cwd or self.config.cwd or os.getcwd()
+        effective_timeout = timeout or self.config.timeout
         try:
-            result = subprocess.run(
-                command,
-                shell=True,
-                text=True,
-                cwd=cwd,
-                env=os.environ | self.config.env,
-                timeout=timeout or self.config.timeout,
-                encoding="utf-8",
-                errors="replace",
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
+            result = (
+                _run_command_in_process_group(command, cwd, os.environ | self.config.env, effective_timeout)
+                if os.name == "posix"
+                else subprocess.run(
+                    command,
+                    shell=True,
+                    text=True,
+                    cwd=cwd,
+                    env=os.environ | self.config.env,
+                    timeout=effective_timeout,
+                    encoding="utf-8",
+                    errors="replace",
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                )
             )
             output = {"output": result.stdout, "returncode": result.returncode, "exception_info": ""}
         except Exception as e:
@@ -77,3 +83,36 @@ class LocalEnvironment:
                 }
             }
         }
+
+
+def _run_command_in_process_group(
+    command: str, cwd: str, env: dict[str, str], timeout: int
+) -> subprocess.CompletedProcess[str]:
+    process = subprocess.Popen(
+        command,
+        shell=True,
+        text=True,
+        cwd=cwd,
+        env=env,
+        encoding="utf-8",
+        errors="replace",
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        start_new_session=True,
+    )
+    try:
+        stdout, _ = process.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        _kill_process_group(process)
+        stdout, _ = process.communicate()
+        raise subprocess.TimeoutExpired(command, timeout, output=stdout)
+    return subprocess.CompletedProcess(command, process.returncode, stdout=stdout, stderr=None)
+
+
+def _kill_process_group(process: subprocess.Popen[str]) -> None:
+    try:
+        os.killpg(process.pid, signal.SIGKILL)
+    except ProcessLookupError:
+        return
+    except OSError:
+        process.kill()

--- a/src/minisweagent/environments/local.py
+++ b/src/minisweagent/environments/local.py
@@ -25,24 +25,8 @@ class LocalEnvironment:
         """Execute a command in the local environment and return the result as a dict."""
         command = action.get("command", "")
         cwd = cwd or self.config.cwd or os.getcwd()
-        effective_timeout = timeout or self.config.timeout
         try:
-            result = (
-                _run_command_in_process_group(command, cwd, os.environ | self.config.env, effective_timeout)
-                if os.name == "posix"
-                else subprocess.run(
-                    command,
-                    shell=True,
-                    text=True,
-                    cwd=cwd,
-                    env=os.environ | self.config.env,
-                    timeout=effective_timeout,
-                    encoding="utf-8",
-                    errors="replace",
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.STDOUT,
-                )
-            )
+            result = _run(command, cwd, os.environ | self.config.env, timeout or self.config.timeout)
             output = {"output": result.stdout, "returncode": result.returncode, "exception_info": ""}
         except Exception as e:
             raw_output = getattr(e, "output", None)
@@ -85,9 +69,8 @@ class LocalEnvironment:
         }
 
 
-def _run_command_in_process_group(
-    command: str, cwd: str, env: dict[str, str], timeout: int
-) -> subprocess.CompletedProcess[str]:
+def _run(command: str, cwd: str, env: dict[str, str], timeout: int) -> subprocess.CompletedProcess[str]:
+    """Like subprocess.run, but kills the whole process group on timeout so no children are orphaned."""
     process = subprocess.Popen(
         command,
         shell=True,
@@ -98,21 +81,12 @@ def _run_command_in_process_group(
         errors="replace",
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
-        start_new_session=True,
+        start_new_session=os.name == "posix",
     )
     try:
         stdout, _ = process.communicate(timeout=timeout)
     except subprocess.TimeoutExpired:
-        _kill_process_group(process)
+        os.killpg(process.pid, signal.SIGKILL) if os.name == "posix" else process.kill()
         stdout, _ = process.communicate()
         raise subprocess.TimeoutExpired(command, timeout, output=stdout)
-    return subprocess.CompletedProcess(command, process.returncode, stdout=stdout, stderr=None)
-
-
-def _kill_process_group(process: subprocess.Popen[str]) -> None:
-    try:
-        os.killpg(process.pid, signal.SIGKILL)
-    except ProcessLookupError:
-        return
-    except OSError:
-        process.kill()
+    return subprocess.CompletedProcess(command, process.returncode, stdout=stdout)

--- a/tests/environments/test_local.py
+++ b/tests/environments/test_local.py
@@ -160,11 +160,19 @@ def test_local_environment_timeout_kills_child_process():
         )
 
         assert result["returncode"] == -1
-        child_pid = int(pid_file.read_text())
+        child_pid = _read_pid(pid_file)
         try:
             assert _process_exited(child_pid)
         finally:
             _kill_process_if_running(child_pid)
+
+
+def _read_pid(pid_file: Path) -> int:
+    for _ in range(50):
+        if pid_file.is_file() and (content := pid_file.read_text().strip()):
+            return int(content)
+        time.sleep(0.1)
+    raise AssertionError(f"child never wrote its pid to {pid_file}")
 
 
 def _process_exited(pid: int) -> bool:

--- a/tests/environments/test_local.py
+++ b/tests/environments/test_local.py
@@ -1,5 +1,9 @@
 import os
+import shlex
+import signal
+import sys
 import tempfile
+import time
 from pathlib import Path
 from unittest.mock import patch
 
@@ -128,6 +132,56 @@ def test_local_environment_timeout():
     assert result["returncode"] == -1
     assert "timed out" in result["exception_info"]
     assert result["extra"]["exception_type"] == "TimeoutExpired"
+
+
+@pytest.mark.skipif(os.name == "nt", reason="process groups are POSIX-specific")
+def test_local_environment_timeout_kills_child_process():
+    """Test that timeout kills shell-spawned child processes."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        pid_file = Path(temp_dir) / "child.pid"
+        script = Path(temp_dir) / "child.py"
+        script.write_text(
+            "\n".join(
+                [
+                    "import os",
+                    "import sys",
+                    "import time",
+                    "from pathlib import Path",
+                    "Path(sys.argv[1]).write_text(str(os.getpid()))",
+                    "while True:",
+                    "    time.sleep(1)",
+                ]
+            )
+        )
+
+        env = LocalEnvironment(timeout=1)
+        result = env.execute(
+            {"command": f"{shlex.quote(sys.executable)} {shlex.quote(str(script))} {shlex.quote(str(pid_file))}"}
+        )
+
+        assert result["returncode"] == -1
+        child_pid = int(pid_file.read_text())
+        try:
+            assert _process_exited(child_pid)
+        finally:
+            _kill_process_if_running(child_pid)
+
+
+def _process_exited(pid: int) -> bool:
+    for _ in range(20):
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return True
+        time.sleep(0.1)
+    return False
+
+
+def _kill_process_if_running(pid: int) -> None:
+    try:
+        os.kill(pid, signal.SIGKILL)
+    except ProcessLookupError:
+        pass
 
 
 def test_local_environment_custom_timeout():


### PR DESCRIPTION
Fixes #826.

LocalEnvironment currently uses subprocess.run(shell=True, timeout=...), which can leave shell-spawned child processes running after the timeout kills only the shell.

This change runs local commands in a new process group on POSIX and kills that group on timeout. Windows keeps the existing subprocess.run path.

Tests:
- pytest tests/environments/test_local.py -q
- ruff check src/minisweagent/environments/local.py tests/environments/test_local.py
- ruff format --check src/minisweagent/environments/local.py tests/environments/test_local.py