### PR TITLE
fix(env): run local commands through bash

### DIFF
--- a/src/minisweagent/environments/local.py
+++ b/src/minisweagent/environments/local.py
@@ -28,7 +28,9 @@ class LocalEnvironment:
         command = action.get("command", "")
         cwd = cwd or self.config.cwd or os.getcwd()
         try:
-            result = _run(command, cwd, os.environ | self.config.env, timeout or self.config.timeout, self.config.interpreter)
+            result = _run(
+                command, cwd, os.environ | self.config.env, timeout or self.config.timeout, self.config.interpreter
+            )
             output = {"output": result.stdout, "returncode": result.returncode, "exception_info": ""}
         except Exception as e:
             raw_output = getattr(e, "output", None)

--- a/src/minisweagent/environments/local.py
+++ b/src/minisweagent/environments/local.py
@@ -14,6 +14,8 @@ class LocalEnvironmentConfig(BaseModel):
     cwd: str = ""
     env: dict[str, str] = {}
     timeout: int = 30
+    interpreter: list[str] = ["bash", "-lc"]
+    """Interpreter to use to execute commands. The command is appended as the final argument."""
 
 
 class LocalEnvironment:
@@ -26,7 +28,7 @@ class LocalEnvironment:
         command = action.get("command", "")
         cwd = cwd or self.config.cwd or os.getcwd()
         try:
-            result = _run(command, cwd, os.environ | self.config.env, timeout or self.config.timeout)
+            result = _run(command, cwd, os.environ | self.config.env, timeout or self.config.timeout, self.config.interpreter)
             output = {"output": result.stdout, "returncode": result.returncode, "exception_info": ""}
         except Exception as e:
             raw_output = getattr(e, "output", None)
@@ -69,11 +71,12 @@ class LocalEnvironment:
         }
 
 
-def _run(command: str, cwd: str, env: dict[str, str], timeout: int) -> subprocess.CompletedProcess[str]:
+def _run(
+    command: str, cwd: str, env: dict[str, str], timeout: int, interpreter: list[str]
+) -> subprocess.CompletedProcess[str]:
     """Like subprocess.run, but kills the whole process group on timeout so no children are orphaned."""
     process = subprocess.Popen(
-        command,
-        shell=True,
+        [*interpreter, command],
         text=True,
         cwd=cwd,
         env=env,

--- a/tests/environments/test_local.py
+++ b/tests/environments/test_local.py
@@ -19,6 +19,7 @@ def test_local_environment_config_defaults():
     assert config.cwd == ""
     assert config.env == {}
     assert config.timeout == 30
+    assert config.interpreter == ["bash", "-lc"]
 
 
 def test_local_environment_basic_execution():
@@ -262,3 +263,13 @@ def test_local_environment_shell_features():
     result = env.execute({"command": "echo $(echo 'nested')"})
     assert result["returncode"] == 0
     assert "nested" in result["output"]
+
+
+@pytest.mark.skipif(os.name == "nt", reason="requires bash")
+def test_local_environment_uses_bash_by_default():
+    """Test that the local environment supports bash-only syntax by default."""
+    env = LocalEnvironment()
+
+    result = env.execute({"command": "cat <(printf 'bash-only')"})
+    assert result["returncode"] == 0
+    assert result["output"] == "bash-only"


### PR DESCRIPTION
## Summary

Fixes #829.

LocalEnvironment advertised and prompted bash commands, but executed them via `subprocess.Popen(..., shell=True)`. On Debian/Ubuntu, Python uses `/bin/sh` for `shell=True`, and `/bin/sh` is commonly `dash`, so bash-only syntax such as process substitution fails even though the tool is named `bash`.

This changes local command execution to use a configurable interpreter, defaulting to `bash -lc`, matching the Docker backend's default interpreter behavior more closely while preserving the existing timeout/process-group handling.

## Validation

- `.venv/bin/python -m pytest tests/environments/test_local.py`
- `.venv/bin/ruff check src/minisweagent/environments/local.py tests/environments/test_local.py`
- `git diff --check`
