### PR TITLE
fix(env): stop or kill docker containers on cleanup

### DIFF
--- a/src/minisweagent/environments/docker.py
+++ b/src/minisweagent/environments/docker.py
@@ -151,9 +151,9 @@ class DockerEnvironment:
             )
 
     def cleanup(self):
-        """Stop and remove the Docker container."""
+        """Stop the Docker container."""
         if getattr(self, "container_id", None) is not None:  # if init fails early, container_id might not be set
-            cmd = f"(timeout 60 {self.config.executable} stop {self.container_id} || {self.config.executable} rm -f {self.container_id}) >/dev/null 2>&1 &"
+            cmd = f"(timeout 60 {self.config.executable} stop {self.container_id} || {self.config.executable} kill {self.container_id}) >/dev/null 2>&1 &"
             subprocess.Popen(cmd, shell=True)
 
     def __del__(self):

--- a/tests/environments/test_docker.py
+++ b/tests/environments/test_docker.py
@@ -53,6 +53,21 @@ def test_docker_environment_config_defaults(executable):
     assert config.executable == executable
 
 
+def test_docker_cleanup_stops_or_kills_container():
+    """Test that cleanup leaves removal policy to the configured run args."""
+    env = DockerEnvironment.__new__(DockerEnvironment)
+    env.container_id = "minisweagent-test"
+    env.config = DockerEnvironmentConfig(image="python:3.11", executable="docker")
+
+    with patch("subprocess.Popen") as popen:
+        env.cleanup()
+
+    popen.assert_called_once_with(
+        "(timeout 60 docker stop minisweagent-test || docker kill minisweagent-test) >/dev/null 2>&1 &",
+        shell=True,
+    )
+
+
 @pytest.mark.slow
 @pytest.mark.parametrize("executable", environment_params)
 def test_docker_environment_basic_execution(executable):


### PR DESCRIPTION
## Summary

Fixes #797.

`DockerEnvironment.cleanup()` currently falls back from `docker stop` to `docker rm -f`. That makes cleanup force removal when `stop` fails, even though removal is already controlled by the configured `run_args` (`--rm` by default) and users may intentionally omit `--rm` to keep stopped containers for debugging.

This changes the fallback to `docker kill`, so cleanup attempts to terminate the container while leaving removal policy to Docker's `--rm` behavior or the user's `run_args` override.

## Validation

- `.venv/bin/python -m pytest tests/environments/test_docker.py -k 'config_defaults or cleanup_stops_or_kills'`
  - `1 passed, 2 skipped, 20 deselected` on this machine because Docker/Podman are not available
- `.venv/bin/ruff check src/minisweagent/environments/docker.py tests/environments/test_docker.py`
- `git diff --check`
