### PR TITLE
Make local command failures explicit in observations

### DIFF
--- a/src/minisweagent/environments/local.py
+++ b/src/minisweagent/environments/local.py
@@ -39,6 +39,7 @@ class LocalEnvironment:
                 "exception_info": f"An error occurred while executing the command: {e}",
                 "extra": {"exception_type": type(e).__name__, "exception": str(e)},
             }
+        _mark_failed_command(output)
         self._check_finished(output)
         return output
 
@@ -90,3 +91,10 @@ def _run(command: str, cwd: str, env: dict[str, str], timeout: int) -> subproces
         stdout, _ = process.communicate()
         raise subprocess.TimeoutExpired(command, timeout, output=stdout)
     return subprocess.CompletedProcess(command, process.returncode, stdout=stdout)
+
+
+def _mark_failed_command(output: dict[str, Any]) -> None:
+    """Make nonzero command exits obvious while preserving command output."""
+    returncode = output.get("returncode")
+    if isinstance(returncode, int) and not isinstance(returncode, bool) and returncode > 0:
+        output["output"] = f"COMMAND FAILED with exit code {returncode}\n{output.get('output', '')}"

--- a/tests/environments/test_local.py
+++ b/tests/environments/test_local.py
@@ -28,6 +28,7 @@ def test_local_environment_basic_execution():
     result = env.execute({"command": "echo 'hello world'"})
     assert result["returncode"] == 0
     assert "hello world" in result["output"]
+    assert "COMMAND FAILED" not in result["output"]
 
 
 def test_local_environment_set_env_variables():
@@ -101,9 +102,11 @@ def test_local_environment_command_failure():
     """Test that command failures are properly captured."""
     env = LocalEnvironment()
 
-    result = env.execute({"command": "exit 1"})
-    assert result["returncode"] == 1
-    assert result["output"] == ""
+    result = env.execute({"command": "echo 'stdout before failure'; echo 'stderr before failure' >&2; exit 7"})
+    assert result["returncode"] == 7
+    assert "COMMAND FAILED with exit code 7" in result["output"]
+    assert "stdout before failure" in result["output"]
+    assert "stderr before failure" in result["output"]
 
 
 def test_local_environment_nonexistent_command():
@@ -130,6 +133,7 @@ def test_local_environment_timeout():
 
     result = env.execute({"command": "sleep 2"})
     assert result["returncode"] == -1
+    assert "COMMAND FAILED with exit code -1" not in result["output"]
     assert "timed out" in result["exception_info"]
     assert result["extra"]["exception_type"] == "TimeoutExpired"
 


### PR DESCRIPTION
## Summary

This makes failed `LocalEnvironment` shell commands more explicit in the observation text.

When a command exits with a positive nonzero return code, the output is prefixed with:

```text
COMMAND FAILED with exit code <code>
```

The original stdout/stderr output is preserved after the marker.

## Motivation

Failed shell commands can be easy for agents to miss when the failure is only visible through the return code or buried in command output. This makes real process exits more obvious without changing agent control flow.

## Scope

This is intentionally scoped to `LocalEnvironment`. Other environment backends are unchanged. A follow-up could move this into shared observation formatting if maintainers want consistent behavior across all environments.

## Testing

```bash
PATH="$PWD/.venv/bin:$PATH" .venv/bin/python -m pytest tests/environments/test_local.py
PATH="$PWD/.venv/bin:$PATH" .venv/bin/python -m pytest tests
```

Results:

```text
20 passed
531 passed, 76 skipped, 1 warning
```