### PR TITLE
fix(run): pass the startup_command as a dict to env.execute() function.

### DIFF
--- a/src/minisweagent/run/benchmarks/swebench.py
+++ b/src/minisweagent/run/benchmarks/swebench.py
@@ -88,7 +88,7 @@ def get_sb_environment(config: dict, instance: dict) -> Environment:
     env = get_environment(env_config)
     if startup_command := config.get("run", {}).get("env_startup_command"):
         startup_command = Template(startup_command, undefined=StrictUndefined).render(**instance)
-        out = env.execute(startup_command)
+        out = env.execute({"command": startup_command})
         if out["returncode"] != 0:
             raise RuntimeError(f"Error executing startup command: {out}")
     return env

--- a/tests/run/test_swebench.py
+++ b/tests/run/test_swebench.py
@@ -1,6 +1,6 @@
 import json
 import re
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from pydantic import BaseModel
@@ -9,6 +9,7 @@ from minisweagent import package_dir
 from minisweagent.models.test_models import DeterministicModel, make_output
 from minisweagent.run.benchmarks.swebench import (
     filter_instances,
+    get_sb_environment,
     get_swebench_docker_image_name,
     main,
     remove_from_preds_file,
@@ -101,6 +102,20 @@ def test_get_image_name_with_complex_instance_id():
     instance = {"instance_id": "project__sub__module__version__1.2.3"}
     expected = "docker.io/swebench/sweb.eval.x86_64.project_1776_sub_1776_module_1776_version_1776_1.2.3:latest"
     assert get_swebench_docker_image_name(instance) == expected
+
+
+def test_get_sb_environment_runs_startup_command_as_dict():
+    """startup_command must be passed to env.execute() as a dict, not a bare string."""
+    fake_env = MagicMock()
+    fake_env.execute.return_value = {"returncode": 0, "output": ""}
+    instance = {"instance_id": "repo1__test1", "image_name": "custom/image:tag"}
+    # The startup_command with {{instance_id}} tested the Jinja render as well.
+    config = {"run": {"env_startup_command": "echo {{instance_id}}"}}
+
+    with patch("minisweagent.run.benchmarks.swebench.get_environment", return_value=fake_env):
+        get_sb_environment(config, instance)
+
+    fake_env.execute.assert_called_once_with({"command": "echo repo1__test1"})
 
 
 def test_filter_instances_no_filters():


### PR DESCRIPTION
## Summary

The get_sb_environment() function in swebench.py is used whenever an environment is needed while running benchmarks. If there exist environment startup commands, they will be passed to the env.execute() function to get executed. However, the env.execute() function expects the commands to be passed as a dict, and in current version the startup_command is passed as a string. An AttributeError will be thrown.


## The Fix

startup_command is not wrapped inside a dict as {"command": startup_command} and passed to env.execute().


## Test

Unit test test_get_sb_environment_runs_startup_command_as_dict() was added to test this exact fix.