### PR TITLE
fix(env): atexit cleanup for DockerEnvironment

### DIFF
--- a/src/minisweagent/environments/docker.py
+++ b/src/minisweagent/environments/docker.py
@@ -1,7 +1,9 @@
+import atexit
 import logging
 import os
 import platform
 import shlex
+import signal
 import subprocess
 import uuid
 from typing import Any
@@ -56,6 +58,8 @@ class DockerEnvironment:
         self.logger = logger or logging.getLogger("minisweagent.environment")
         self.container_id: str | None = None
         self.config = config_class(**kwargs)
+        self._cleaned = False
+        atexit.register(self.cleanup)
         self._start_container()
 
     def get_template_vars(self, **kwargs) -> dict[str, Any]:
@@ -152,7 +156,10 @@ class DockerEnvironment:
 
     def cleanup(self):
         """Stop and remove the Docker container."""
-        if getattr(self, "container_id", None) is not None:  # if init fails early, container_id might not be set
+        if self._cleaned:
+            return
+        self._cleaned = True
+        if getattr(self, "container_id", None) is not None:
             cmd = f"(timeout 60 {self.config.executable} stop {self.container_id} || {self.config.executable} rm -f {self.container_id}) >/dev/null 2>&1 &"
             subprocess.Popen(cmd, shell=True)
 

--- a/src/minisweagent/environments/docker.py
+++ b/src/minisweagent/environments/docker.py
@@ -3,7 +3,6 @@ import logging
 import os
 import platform
 import shlex
-import signal
 import subprocess
 import uuid
 from typing import Any

--- a/tests/environments/test_docker_cleanup.py
+++ b/tests/environments/test_docker_cleanup.py
@@ -1,0 +1,45 @@
+"""Tests for DockerEnvironment cleanup idempotency and atexit behavior."""
+
+import subprocess
+
+import pytest
+
+from minisweagent.environments.docker import DockerEnvironment
+
+
+def _docker_available(executable="docker"):
+    try:
+        subprocess.run([executable, "version"], capture_output=True, check=True, timeout=5)
+        return True
+    except (subprocess.CalledProcessError, FileNotFoundError, subprocess.TimeoutExpired):
+        return False
+
+
+env_params = [
+    pytest.param("docker", marks=pytest.mark.skipif(not _docker_available(), reason="Docker not available"), id="docker"),
+    pytest.param(
+        "podman",
+        marks=pytest.mark.skipif(not _docker_available("podman"), reason="Podman not available"),
+        id="podman",
+    ),
+]
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("executable", env_params)
+def test_cleanup_idempotent(executable):
+    """Multiple cleanup() calls should not raise."""
+    env = DockerEnvironment(image="python:3.11", executable=executable)
+    env.cleanup()
+    env.cleanup()
+    env.cleanup()
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("executable", env_params)
+def test_cleaned_flag(executable):
+    """_cleaned flag should be True after cleanup()."""
+    env = DockerEnvironment(image="python:3.11", executable=executable)
+    assert not env._cleaned
+    env.cleanup()
+    assert env._cleaned

--- a/tests/environments/test_docker_cleanup.py
+++ b/tests/environments/test_docker_cleanup.py
@@ -16,7 +16,9 @@ def _docker_available(executable="docker"):
 
 
 env_params = [
-    pytest.param("docker", marks=pytest.mark.skipif(not _docker_available(), reason="Docker not available"), id="docker"),
+    pytest.param(
+        "docker", marks=pytest.mark.skipif(not _docker_available(), reason="Docker not available"), id="docker"
+    ),
     pytest.param(
         "podman",
         marks=pytest.mark.skipif(not _docker_available("podman"), reason="Podman not available"),


### PR DESCRIPTION
## Problem

The `DockerEnvironment.cleanup()` method was only called via `__del__`, which is not guaranteed to execute on abnormal exit (Ctrl+C, interpreter crash). This could leave Docker containers running as zombie processes.

## Solution

Register `atexit.register(self.cleanup)` in `__init__`, which guarantees execution on normal Python exit. Add a `_cleaned` flag to make `cleanup()` idempotent for the case where both `atexit` and `__del__` fire.

## Changes

- `src/minisweagent/environments/docker.py`: Add `atexit.register`, add `_cleaned` idempotency flag
- `tests/environments/test_docker_cleanup.py`: New tests for cleanup idempotency

## Testing

- `test_cleanup_idempotent`: Verifies multiple `cleanup()` calls do not raise
- `test_cleaned_flag`: Verifies `_cleaned` is set after cleanup

## Notes for Reviewer

- No API changes — all existing usage patterns remain compatible
- `atexit` is stdlib, no new dependencies
- `_cleaned` flag protects against the atexit + `__del__` double-call edge case
