### PR TITLE
Reject empty config override keys

### DIFF
--- a/src/minisweagent/config/__init__.py
+++ b/src/minisweagent/config/__init__.py
@@ -42,6 +42,8 @@ def _key_value_spec_to_nested_dict(config_spec: str) -> dict:
     except json.JSONDecodeError:
         pass
     keys = key.split(".")
+    if any(k == "" for k in keys):
+        raise ValueError(f"Invalid config spec {config_spec!r}: empty config key")
     result = {}
     current = result
     for k in keys[:-1]:

--- a/tests/config/test_init.py
+++ b/tests/config/test_init.py
@@ -83,6 +83,11 @@ class TestKeyValueSpecToNestedDict:
     def test_zero_float(self):
         assert _key_value_spec_to_nested_dict("value=0.0") == {"value": 0.0}
 
+    @pytest.mark.parametrize("config_spec", ["=value", "model..name=value", "model.=value"])
+    def test_empty_key_raises_value_error(self, config_spec):
+        with pytest.raises(ValueError, match="empty config key"):
+            _key_value_spec_to_nested_dict(config_spec)
+
 
 class TestGetConfigFromSpec:
     """Tests for get_config_from_spec function."""


### PR DESCRIPTION
## What changed

This rejects empty keys in command-line config override specs such as `=value`, `model..name=value`, or `model.=value`.

## Why

`-c key=value` overrides are merged into the agent config. Empty key segments are almost always typos, but they were previously accepted and produced dictionaries with `""` keys. That can silently pollute the merged config and make the real mistake harder to diagnose.

Valid overrides and JSON value parsing are unchanged.

## Validation

- `PYTHONPATH=src python -m pytest tests\config\test_init.py -q`
- `python -m ruff check src\minisweagent\config\__init__.py tests\config\test_init.py`
- `python -m ruff format --check src\minisweagent\config\__init__.py tests\config\test_init.py`
- `git diff --check`