### PR TITLE
fix: remove startup-banner emoji that crashes import on non-UTF stdout

### DIFF
--- a/src/minisweagent/__init__.py
+++ b/src/minisweagent/__init__.py
@@ -29,7 +29,7 @@ global_config_file = Path(global_config_dir) / ".env"
 
 if not os.getenv("MSWEA_SILENT_STARTUP"):
     Console().print(
-        f"👋 This is [bold green]mini-swe-agent[/bold green] version [bold green]{__version__}[/bold green].\n"
+        f"This is [bold green]mini-swe-agent[/bold green] version [bold green]{__version__}[/bold green].\n"
         f"Check the [bold red]v2 migration guide[/] at [bold red]https://klieret.short.gy/mini-v2-migration[/]\n"
         f"Loading global config from [bold green]'{global_config_file}'[/bold green]",
     )

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,17 @@
+"""Tests for minisweagent.__init__."""
+
+import os
+import subprocess
+import sys
+
+
+def test_startup_banner_survives_non_utf8_stdout(tmp_path):
+    """Importing the package must not crash when stdout can't encode the startup banner (e.g. Windows cp1252)."""
+    env = {
+        **os.environ,
+        "PYTHONIOENCODING": "cp1252",
+        "MSWEA_SILENT_STARTUP": "",
+        "MSWEA_GLOBAL_CONFIG_DIR": str(tmp_path),
+    }
+    result = subprocess.run([sys.executable, "-c", "import minisweagent"], capture_output=True, text=True, env=env)
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary

The startup banner in `src/minisweagent/__init__.py` prints a 👋 through rich's `Console`. When stdout can't encode that character the write raises `UnicodeEncodeError`, and `import minisweagent` dies before anything runs. This hits the default Windows console (cp1252), redirected or piped output, and any run with `PYTHONIOENCODING=cp1252` or `LANG=C`.

Removing the emoji makes the banner ASCII-only, so the import no longer depends on the terminal encoding. This is the emoji removal suggested on the issue, not a conditional guard.

## Test

`tests/test_init.py` imports the package in a subprocess with `PYTHONIOENCODING=cp1252` and asserts it exits cleanly. It fails before this change and passes after. Because it forces the encoding, it also reproduces and runs on the Linux CI, no Windows machine needed.

Fixes #885
