### PR TITLE
fix(benchmarks): don't mutate shared config across worker threads in get_sb_environment

### DIFF
--- a/src/minisweagent/run/benchmarks/swebench.py
+++ b/src/minisweagent/run/benchmarks/swebench.py
@@ -77,7 +77,7 @@ def get_swebench_docker_image_name(instance: dict) -> str:
 
 
 def get_sb_environment(config: dict, instance: dict) -> Environment:
-    env_config = config.setdefault("environment", {})
+    env_config = {**config.get("environment", {})}
     env_config["environment_class"] = env_config.get("environment_class", "docker")
     image_name = get_swebench_docker_image_name(instance)
     if env_config["environment_class"] in ["docker", "swerex_modal"]:

--- a/tests/run/test_swebench.py
+++ b/tests/run/test_swebench.py
@@ -118,6 +118,20 @@ def test_get_sb_environment_runs_startup_command_as_dict():
     fake_env.execute.assert_called_once_with({"command": "echo repo1__test1"})
 
 
+def test_get_sb_environment_does_not_mutate_shared_config():
+    """The config dict is shared across worker threads, so resolving the per-instance image must not mutate it."""
+    config = {"environment": {"environment_class": "docker"}}
+    instance = {"instance_id": "repo1__test1", "image_name": "custom/image:tag"}
+
+    with patch(
+        "minisweagent.run.benchmarks.swebench.get_environment", return_value=MagicMock()
+    ) as mock_get_environment:
+        get_sb_environment(config, instance)
+
+    assert mock_get_environment.call_args.args[0]["image"] == "custom/image:tag"
+    assert "image" not in config["environment"]
+
+
 def test_filter_instances_no_filters():
     """Test filter_instances with no filtering applied"""
     instances = [{"instance_id": "repo1__test1"}, {"instance_id": "repo2__test2"}, {"instance_id": "repo3__test3"}]


### PR DESCRIPTION
## Summary

In batch mode, `main` builds one `config` dict and passes the same object to every `ThreadPoolExecutor` worker. Inside `get_sb_environment`, `config.setdefault("environment", {})` returned an alias to that shared dict, and the next lines wrote the per-instance Docker image into it. With `--workers >1`, one thread's `env_config["image"]` write can land inside another thread's window before its `get_environment` call reads the image, so an instance can build the wrong container and silently produce a result for the wrong repo. It is timing-dependent and only affects parallel runs, so it is rare, but the failure is silent (scored as a normal failed instance).

`get_sb_environment` now builds `env_config` from a copy (`{**config.get("environment", {})}`), so resolving the per-instance image never touches the shared config. This matches what `programbench.py` already does with a per-instance `copy.deepcopy(config)`. The other reads on the worker path are already safe: `get_model` and `get_environment` both copy their config internally.

## Test

Added `test_get_sb_environment_does_not_mutate_shared_config` in `tests/run/test_swebench.py`, following the existing `patch("...get_environment")` pattern in that file. It asserts the correct per-instance image still reaches `get_environment` and that the shared `config` is left untouched. It fails before this change and passes after, deterministically (no threading or Docker needed).
