### PR TITLE
enh(models): rename command execution tool to shell

### DIFF
--- a/src/minisweagent/config/benchmarks/programbench.yaml
+++ b/src/minisweagent/config/benchmarks/programbench.yaml
@@ -121,7 +121,7 @@ agent:
     **CRITICAL REQUIREMENTS:**
 
     - Your response SHOULD include reasoning text explaining what you're doing
-    - Your response MUST include AT LEAST ONE bash tool call
+    - Your response MUST include AT LEAST ONE shell tool call
     - Directory or environment variable changes are not persistent. Every action is executed in a new subshell.
     - However, you can prefix any action with `MY_ENV_VAR=MY_VALUE cd /path/to/working/dir && ...` or write/load environment variables from files
     - Submit your changes and finish your work by issuing the following command: `echo COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT`.
@@ -131,7 +131,7 @@ agent:
     <example_response>
     I need to understand the structure of the repository first. Let me check what files are in the current directory to get a better understanding of the codebase.
 
-    [Makes bash tool call with {"command": "ls -la"} as arguments]
+    [Makes shell tool call with {"command": "ls -la"} as arguments]
     </example_response>
 
     <system_information>
@@ -258,7 +258,7 @@ model:
     {%- endif %}
   format_error_template: |
     {% if finish_reason is defined and finish_reason in ["length", "tool_calls"] -%}
-    Your previous response reached the output token limit (finish_reason={{ finish_reason }}) before you produced a tool call, so it was cut off. Respond more concisely and finish with exactly one bash tool call. If you need to think more, do so briefly.
+    Your previous response reached the output token limit (finish_reason={{ finish_reason }}) before you produced a tool call, so it was cut off. Respond more concisely and finish with exactly one shell tool call. If you need to think more, do so briefly.
     {%- else -%}
     Tool call error:
 
@@ -268,10 +268,10 @@ model:
 
     Here is general guidance on how to submit correct toolcalls:
 
-    Every response needs to use the 'bash' tool at least once to execute commands.
+    Every response needs to use the 'shell' tool at least once to execute commands.
 
-    Call the bash tool with your command as the argument:
-    - Tool: bash
+    Call the shell tool with your command as the argument:
+    - Tool: shell
     - Arguments: {"command": "your_command_here"}
 
     If you have completed your assignment, please consult the first message about how to

--- a/src/minisweagent/config/benchmarks/swebench.yaml
+++ b/src/minisweagent/config/benchmarks/swebench.yaml
@@ -20,7 +20,7 @@ agent:
     For each response:
 
     1. Include a THOUGHT section explaining your reasoning and what you're trying to accomplish
-    2. Provide one or more bash tool calls to execute
+    2. Provide one or more shell tool calls to execute
 
     ## Important Boundaries
 
@@ -52,7 +52,7 @@ agent:
     **CRITICAL REQUIREMENTS:**
 
     - Your response SHOULD include reasoning text explaining what you're doing
-    - Your response MUST include AT LEAST ONE bash tool call. You can make MULTIPLE tool calls in a single response when the commands are independent (e.g., searching multiple files, reading different parts of the codebase).
+    - Your response MUST include AT LEAST ONE shell tool call. You can make MULTIPLE tool calls in a single response when the commands are independent (e.g., searching multiple files, reading different parts of the codebase).
     - Directory or environment variable changes are not persistent. Every action is executed in a new subshell.
     - However, you can prefix any action with `MY_ENV_VAR=MY_VALUE cd /path/to/working/dir && ...` or write/load environment variables from files
 
@@ -60,7 +60,7 @@ agent:
     <example_response>
     I need to understand the Builder-related code. Let me find relevant files and check the project structure.
 
-    [Makes multiple bash tool calls: {"command": "ls -la"}, {"command": "find src -name '*.java' | grep -i builder"}, {"command": "cat README.md | head -50"}]
+    [Makes multiple shell tool calls: {"command": "ls -la"}, {"command": "find src -name '*.java' | grep -i builder"}, {"command": "cat README.md | head -50"}]
     </example_response>
 
     ## Environment Details
@@ -158,7 +158,7 @@ model:
     {%- endif -%}
   format_error_template: |
     {% if finish_reason is defined and finish_reason in ["length", "tool_calls"] -%}
-    Your previous response reached the output token limit (finish_reason={{ finish_reason }}) before you produced a tool call, so it was cut off. Respond more concisely and finish with exactly one bash tool call. If you need to think more, do so briefly.
+    Your previous response reached the output token limit (finish_reason={{ finish_reason }}) before you produced a tool call, so it was cut off. Respond more concisely and finish with exactly one shell tool call. If you need to think more, do so briefly.
     {%- else -%}
     Tool call error:
 
@@ -168,10 +168,10 @@ model:
 
     Here is general guidance on how to submit correct toolcalls:
 
-    Every response needs to use the 'bash' tool at least once to execute commands.
+    Every response needs to use the 'shell' tool at least once to execute commands.
 
-    Call the bash tool with your command as the argument:
-    - Tool: bash
+    Call the shell tool with your command as the argument:
+    - Tool: shell
     - Arguments: {"command": "your_command_here"}
 
     If you have completed your assignment, please consult the first message about how to

--- a/src/minisweagent/config/mini.yaml
+++ b/src/minisweagent/config/mini.yaml
@@ -35,7 +35,7 @@ agent:
     **CRITICAL REQUIREMENTS:**
 
     - Your response SHOULD include reasoning text explaining what you're doing
-    - Your response MUST include AT LEAST ONE bash tool call
+    - Your response MUST include AT LEAST ONE shell tool call
     - Directory or environment variable changes are not persistent. Every action is executed in a new subshell.
     - However, you can prefix any action with `MY_ENV_VAR=MY_VALUE cd /path/to/working/dir && ...` or write/load environment variables from files
     - Submit your changes and finish your work by issuing the following command: `echo COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT`.
@@ -45,7 +45,7 @@ agent:
     <example_response>
     I need to understand the structure of the repository first. Let me check what files are in the current directory to get a better understanding of the codebase.
 
-    [Makes bash tool call with {"command": "ls -la"} as arguments]
+    [Makes shell tool call with {"command": "ls -la"} as arguments]
     </example_response>
 
     <system_information>
@@ -128,7 +128,7 @@ model:
     {%- endif -%}
   format_error_template: |
     {% if finish_reason is defined and finish_reason in ["length", "tool_calls"] -%}
-    Your previous response reached the output token limit (finish_reason={{ finish_reason }}) before you produced a tool call, so it was cut off. Respond more concisely and finish with exactly one bash tool call. If you need to think more, do so briefly.
+    Your previous response reached the output token limit (finish_reason={{ finish_reason }}) before you produced a tool call, so it was cut off. Respond more concisely and finish with exactly one shell tool call. If you need to think more, do so briefly.
     {%- else -%}
     Tool call error:
 
@@ -138,10 +138,10 @@ model:
 
     Here is general guidance on how to submit correct toolcalls:
 
-    Every response needs to use the 'bash' tool at least once to execute commands.
+    Every response needs to use the 'shell' tool at least once to execute commands.
 
-    Call the bash tool with your command as the argument:
-    - Tool: bash
+    Call the shell tool with your command as the argument:
+    - Tool: shell
     - Arguments: {"command": "your_command_here"}
 
     If you want to end the task, please issue the following command: `echo COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT`

--- a/src/minisweagent/models/litellm_model.py
+++ b/src/minisweagent/models/litellm_model.py
@@ -12,7 +12,7 @@ from pydantic import BaseModel
 from minisweagent.exceptions import FormatError
 from minisweagent.models import GLOBAL_MODEL_STATS
 from minisweagent.models.utils.actions_toolcall import (
-    BASH_TOOL,
+    SHELL_TOOL,
     format_toolcall_observation_messages,
     parse_toolcall_actions,
 )
@@ -66,7 +66,7 @@ class LitellmModel:
             return litellm.completion(
                 model=self.config.model_name,
                 messages=messages,
-                tools=[BASH_TOOL],
+                tools=[SHELL_TOOL],
                 **(self.config.model_kwargs | kwargs),
             )
         except litellm.exceptions.AuthenticationError as e:

--- a/src/minisweagent/models/litellm_response_model.py
+++ b/src/minisweagent/models/litellm_response_model.py
@@ -8,7 +8,7 @@ from minisweagent.exceptions import FormatError
 from minisweagent.models import GLOBAL_MODEL_STATS
 from minisweagent.models.litellm_model import LitellmModel, LitellmModelConfig
 from minisweagent.models.utils.actions_toolcall_response import (
-    BASH_TOOL_RESPONSE_API,
+    SHELL_TOOL_RESPONSE_API,
     finish_reason_from_responses_api,
     format_toolcall_observation_messages,
     parse_toolcall_actions_response,
@@ -42,7 +42,7 @@ class LitellmResponseModel(LitellmModel):
             return litellm.responses(
                 model=self.config.model_name,
                 input=messages,
-                tools=[BASH_TOOL_RESPONSE_API],
+                tools=[SHELL_TOOL_RESPONSE_API],
                 **(self.config.model_kwargs | kwargs),
             )
         except litellm.exceptions.AuthenticationError as e:

--- a/src/minisweagent/models/openrouter_model.py
+++ b/src/minisweagent/models/openrouter_model.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel
 from minisweagent.exceptions import FormatError
 from minisweagent.models import GLOBAL_MODEL_STATS
 from minisweagent.models.utils.actions_toolcall import (
-    BASH_TOOL,
+    SHELL_TOOL,
     format_toolcall_observation_messages,
     parse_toolcall_actions,
 )
@@ -69,7 +69,7 @@ class OpenRouterModel:
         payload = {
             "model": self.config.model_name,
             "messages": messages,
-            "tools": [BASH_TOOL],
+            "tools": [SHELL_TOOL],
             "usage": {"include": True},
             **(self.config.model_kwargs | kwargs),
         }

--- a/src/minisweagent/models/openrouter_response_model.py
+++ b/src/minisweagent/models/openrouter_response_model.py
@@ -14,7 +14,7 @@ from minisweagent.models.openrouter_model import (
     OpenRouterRateLimitError,
 )
 from minisweagent.models.utils.actions_toolcall_response import (
-    BASH_TOOL_RESPONSE_API,
+    SHELL_TOOL_RESPONSE_API,
     finish_reason_from_responses_api,
     format_toolcall_observation_messages,
     parse_toolcall_actions_response,
@@ -49,7 +49,7 @@ class OpenRouterResponseModel(OpenRouterModel):
         payload = {
             "model": self.config.model_name,
             "input": messages,
-            "tools": [BASH_TOOL_RESPONSE_API],
+            "tools": [SHELL_TOOL_RESPONSE_API],
             **(self.config.model_kwargs | kwargs),
         }
         try:

--- a/src/minisweagent/models/portkey_model.py
+++ b/src/minisweagent/models/portkey_model.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel
 from minisweagent.exceptions import FormatError
 from minisweagent.models import GLOBAL_MODEL_STATS
 from minisweagent.models.utils.actions_toolcall import (
-    BASH_TOOL,
+    SHELL_TOOL,
     format_toolcall_observation_messages,
     parse_toolcall_actions,
 )
@@ -92,7 +92,7 @@ class PortkeyModel:
         return self.client.chat.completions.create(
             model=self.config.model_name,
             messages=messages,
-            tools=[BASH_TOOL],
+            tools=[SHELL_TOOL],
             **(self.config.model_kwargs | kwargs),
         )
 

--- a/src/minisweagent/models/portkey_response_model.py
+++ b/src/minisweagent/models/portkey_response_model.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel
 from minisweagent.exceptions import FormatError
 from minisweagent.models import GLOBAL_MODEL_STATS
 from minisweagent.models.utils.actions_toolcall_response import (
-    BASH_TOOL_RESPONSE_API,
+    SHELL_TOOL_RESPONSE_API,
     finish_reason_from_responses_api,
     format_toolcall_observation_messages,
     parse_toolcall_actions_response,
@@ -75,7 +75,7 @@ class PortkeyResponseAPIModel:
         return self.client.responses.create(
             model=self.config.model_name,
             input=messages,
-            tools=[BASH_TOOL_RESPONSE_API],
+            tools=[SHELL_TOOL_RESPONSE_API],
             **(self.config.model_kwargs | kwargs),
         )
 

--- a/src/minisweagent/models/requesty_model.py
+++ b/src/minisweagent/models/requesty_model.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel
 from minisweagent.exceptions import FormatError
 from minisweagent.models import GLOBAL_MODEL_STATS
 from minisweagent.models.utils.actions_toolcall import (
-    BASH_TOOL,
+    SHELL_TOOL,
     format_toolcall_observation_messages,
     parse_toolcall_actions,
 )
@@ -75,7 +75,7 @@ class RequestyModel:
         payload = {
             "model": self.config.model_name,
             "messages": messages,
-            "tools": [BASH_TOOL],
+            "tools": [SHELL_TOOL],
             **(self.config.model_kwargs | kwargs),
         }
 

--- a/src/minisweagent/models/test_models.py
+++ b/src/minisweagent/models/test_models.py
@@ -61,7 +61,7 @@ def make_response_api_output(content: str | None, actions: list[dict]) -> dict:
             {
                 "type": "function_call",
                 "call_id": action["tool_call_id"],
-                "name": "bash",
+                "name": "shell",
                 "arguments": f'{{"command": "{action["command"]}"}}',
             }
         )

--- a/src/minisweagent/models/utils/actions_toolcall.py
+++ b/src/minisweagent/models/utils/actions_toolcall.py
@@ -8,10 +8,10 @@ from jinja2 import StrictUndefined, Template
 from minisweagent.exceptions import FormatError
 from minisweagent.models.utils.openai_multimodal import expand_multimodal_content
 
-BASH_TOOL = {
+SHELL_TOOL = {
     "type": "function",
     "function": {
-        "name": "bash",
+        "name": "shell",
         "description": "Execute a shell command",
         "parameters": {
             "type": "object",
@@ -57,10 +57,10 @@ def parse_toolcall_actions(
             args = json.loads(tool_call.function.arguments)
         except Exception as e:
             error_msg = f"Error parsing tool call arguments: {e}."
-        if tool_call.function.name != "bash":
+        if tool_call.function.name != "shell":
             error_msg += f"Unknown tool '{tool_call.function.name}'."
         if not isinstance(args, dict) or "command" not in args:
-            error_msg += "Missing 'command' argument in bash tool call."
+            error_msg += "Missing 'command' argument in shell tool call."
         if error_msg:
             raise FormatError(
                 {

--- a/src/minisweagent/models/utils/actions_toolcall_response.py
+++ b/src/minisweagent/models/utils/actions_toolcall_response.py
@@ -8,9 +8,9 @@ from jinja2 import StrictUndefined, Template
 from minisweagent.exceptions import FormatError
 
 # OpenRouter/OpenAI Responses API uses a flat structure (no nested "function" key)
-BASH_TOOL_RESPONSE_API = {
+SHELL_TOOL_RESPONSE_API = {
     "type": "function",
-    "name": "bash",
+    "name": "shell",
     "description": "Execute a shell command",
     "parameters": {
         "type": "object",
@@ -62,7 +62,7 @@ def parse_toolcall_actions_response(
 
     Filters for function_call items and parses them.
     Response API format has name/arguments at top level with call_id:
-    {"type": "function_call", "call_id": "...", "name": "bash", "arguments": "..."}
+    {"type": "function_call", "call_id": "...", "name": "shell", "arguments": "..."}
 
     ``template_kwargs`` are extra variables exposed to ``format_error_template`` (e.g.
     ``{"finish_reason": ...}``), matching ``parse_toolcall_actions``.
@@ -90,10 +90,10 @@ def parse_toolcall_actions_response(
             args = json.loads(tool_call.get("arguments", "{}"))
         except Exception as e:
             error_msg = f"Error parsing tool call arguments: {e}."
-        if tool_call.get("name") != "bash":
+        if tool_call.get("name") != "shell":
             error_msg += f"Unknown tool '{tool_call.get('name')}'."
         if not isinstance(args, dict) or "command" not in args:
-            error_msg += "Missing 'command' argument in bash tool call."
+            error_msg += "Missing 'command' argument in shell tool call."
         if error_msg:
             error_text = Template(format_error_template, undefined=StrictUndefined).render(
                 error=error_msg.strip(), actions=[], **template_kwargs

--- a/tests/models/test_actions_toolcall.py
+++ b/tests/models/test_actions_toolcall.py
@@ -4,7 +4,7 @@ import pytest
 
 from minisweagent.exceptions import FormatError
 from minisweagent.models.utils.actions_toolcall import (
-    BASH_TOOL,
+    SHELL_TOOL,
     format_toolcall_observation_messages,
     parse_toolcall_actions,
 )
@@ -29,16 +29,16 @@ class TestParseToolcallActions:
         assert exc.value.messages[0]["content"] == "cut off"
         # bad-arguments path
         bad = MagicMock()
-        bad.function.name = "bash"
+        bad.function.name = "shell"
         bad.function.arguments = "{not json"
         bad.id = "call_1"
         with pytest.raises(FormatError) as exc:
             parse_toolcall_actions([bad], format_error_template=template, template_kwargs={"finish_reason": "length"})
         assert exc.value.messages[0]["content"] == "cut off"
 
-    def test_valid_bash_tool_call(self):
+    def test_valid_shell_tool_call(self):
         tool_call = MagicMock()
-        tool_call.function.name = "bash"
+        tool_call.function.name = "shell"
         tool_call.function.arguments = '{"command": "echo hello"}'
         tool_call.id = "call_123"
         assert parse_toolcall_actions([tool_call], format_error_template="{{ error }}") == [
@@ -49,7 +49,7 @@ class TestParseToolcallActions:
         calls = []
         for i in range(3):
             tc = MagicMock()
-            tc.function.name = "bash"
+            tc.function.name = "shell"
             tc.function.arguments = f'{{"command": "cmd{i}"}}'
             tc.id = f"call_{i}"
             calls.append(tc)
@@ -69,7 +69,7 @@ class TestParseToolcallActions:
 
     def test_invalid_json_raises_format_error(self):
         tool_call = MagicMock()
-        tool_call.function.name = "bash"
+        tool_call.function.name = "shell"
         tool_call.function.arguments = "not valid json"
         tool_call.id = "call_1"
         with pytest.raises(FormatError) as exc_info:
@@ -78,7 +78,7 @@ class TestParseToolcallActions:
 
     def test_missing_command_raises_format_error(self):
         tool_call = MagicMock()
-        tool_call.function.name = "bash"
+        tool_call.function.name = "shell"
         tool_call.function.arguments = '{"other_arg": "value"}'
         tool_call.id = "call_1"
         with pytest.raises(FormatError) as exc_info:
@@ -135,9 +135,9 @@ class TestFormatToolcallObservationMessages:
         assert result[0]["extra"]["detail"] == "more"
 
 
-class TestBashTool:
-    def test_bash_tool_structure(self):
-        assert BASH_TOOL["type"] == "function"
-        assert BASH_TOOL["function"]["name"] == "bash"
-        assert "command" in BASH_TOOL["function"]["parameters"]["properties"]
-        assert "command" in BASH_TOOL["function"]["parameters"]["required"]
+class TestShellTool:
+    def test_shell_tool_structure(self):
+        assert SHELL_TOOL["type"] == "function"
+        assert SHELL_TOOL["function"]["name"] == "shell"
+        assert "command" in SHELL_TOOL["function"]["parameters"]["properties"]
+        assert "command" in SHELL_TOOL["function"]["parameters"]["required"]

--- a/tests/models/test_litellm_model.py
+++ b/tests/models/test_litellm_model.py
@@ -4,7 +4,7 @@ import pytest
 
 from minisweagent.exceptions import FormatError
 from minisweagent.models.litellm_model import LitellmModel, LitellmModelConfig
-from minisweagent.models.utils.actions_toolcall import BASH_TOOL
+from minisweagent.models.utils.actions_toolcall import SHELL_TOOL
 
 
 class TestLitellmModelConfig:
@@ -26,7 +26,7 @@ class TestLitellmModel:
     @patch("minisweagent.models.litellm_model.litellm.cost_calculator.completion_cost")
     def test_query_includes_bash_tool(self, mock_cost, mock_completion):
         tool_call = MagicMock()
-        tool_call.function.name = "bash"
+        tool_call.function.name = "shell"
         tool_call.function.arguments = '{"command": "echo test"}'
         tool_call.id = "call_1"
         mock_completion.return_value = _mock_litellm_response([tool_call])
@@ -36,13 +36,13 @@ class TestLitellmModel:
         model.query([{"role": "user", "content": "test"}])
 
         mock_completion.assert_called_once()
-        assert mock_completion.call_args.kwargs["tools"] == [BASH_TOOL]
+        assert mock_completion.call_args.kwargs["tools"] == [SHELL_TOOL]
 
     @patch("minisweagent.models.litellm_model.litellm.completion")
     @patch("minisweagent.models.litellm_model.litellm.cost_calculator.completion_cost")
     def test_parse_actions_valid_tool_call(self, mock_cost, mock_completion):
         tool_call = MagicMock()
-        tool_call.function.name = "bash"
+        tool_call.function.name = "shell"
         tool_call.function.arguments = '{"command": "ls -la"}'
         tool_call.id = "call_abc"
         mock_completion.return_value = _mock_litellm_response([tool_call])

--- a/tests/models/test_portkey_model.py
+++ b/tests/models/test_portkey_model.py
@@ -58,7 +58,9 @@ def test_portkey_model_query():
     mock_message.model_dump.return_value = {
         "role": "assistant",
         "content": None,
-        "tool_calls": [{"id": "call_123", "function": {"name": "shell", "arguments": '{"command": "echo \'Hello!\'"}'}}],
+        "tool_calls": [
+            {"id": "call_123", "function": {"name": "shell", "arguments": '{"command": "echo \'Hello!\'"}'}}
+        ],
     }
     mock_choice.message = mock_message
     mock_response.choices = [mock_choice]

--- a/tests/models/test_portkey_model.py
+++ b/tests/models/test_portkey_model.py
@@ -6,7 +6,7 @@ import pytest
 
 from minisweagent.models import GLOBAL_MODEL_STATS
 from minisweagent.models.portkey_model import PortkeyModel, PortkeyModelConfig
-from minisweagent.models.utils.actions_toolcall import BASH_TOOL
+from minisweagent.models.utils.actions_toolcall import SHELL_TOOL
 
 
 def test_portkey_model_missing_api_key():
@@ -51,14 +51,14 @@ def test_portkey_model_query():
 
     # Response uses tool_calls
     mock_tool_call.id = "call_123"
-    mock_tool_call.function.name = "bash"
+    mock_tool_call.function.name = "shell"
     mock_tool_call.function.arguments = json.dumps({"command": "echo 'Hello!'"})
     mock_message.tool_calls = [mock_tool_call]
     mock_message.content = None
     mock_message.model_dump.return_value = {
         "role": "assistant",
         "content": None,
-        "tool_calls": [{"id": "call_123", "function": {"name": "bash", "arguments": '{"command": "echo \'Hello!\'"}'}}],
+        "tool_calls": [{"id": "call_123", "function": {"name": "shell", "arguments": '{"command": "echo \'Hello!\'"}'}}],
     }
     mock_choice.message = mock_message
     mock_response.choices = [mock_choice]
@@ -83,7 +83,7 @@ def test_portkey_model_query():
 
                 # Verify the API was called correctly with tools
                 mock_client.chat.completions.create.assert_called_once_with(
-                    model="gpt-4o", messages=messages, tools=[BASH_TOOL]
+                    model="gpt-4o", messages=messages, tools=[SHELL_TOOL]
                 )
                 # Verify cost calculation was called
                 mock_cost.assert_called_once_with(mock_response.model_copy(), model=None)
@@ -116,14 +116,14 @@ def test_portkey_model_cost_tracking_ignore_errors():
 
     # Response uses tool_calls
     mock_tool_call.id = "call_456"
-    mock_tool_call.function.name = "bash"
+    mock_tool_call.function.name = "shell"
     mock_tool_call.function.arguments = json.dumps({"command": "echo test"})
     mock_message.tool_calls = [mock_tool_call]
     mock_message.content = None
     mock_message.model_dump.return_value = {
         "role": "assistant",
         "content": None,
-        "tool_calls": [{"id": "call_456", "function": {"name": "bash", "arguments": '{"command": "echo test"}'}}],
+        "tool_calls": [{"id": "call_456", "function": {"name": "shell", "arguments": '{"command": "echo test"}'}}],
     }
     mock_choice.message = mock_message
     mock_response.choices = [mock_choice]
@@ -161,7 +161,7 @@ def test_portkey_model_cost_validation_error():
     mock_tool_call = MagicMock()
 
     mock_tool_call.id = "call_789"
-    mock_tool_call.function.name = "bash"
+    mock_tool_call.function.name = "shell"
     mock_tool_call.function.arguments = json.dumps({"command": "echo test"})
     mock_message.tool_calls = [mock_tool_call]
     mock_message.content = None

--- a/tests/models/test_portkey_response_model.py
+++ b/tests/models/test_portkey_response_model.py
@@ -5,7 +5,7 @@ import pytest
 
 from minisweagent.models import GLOBAL_MODEL_STATS
 from minisweagent.models.portkey_response_model import PortkeyResponseAPIModel
-from minisweagent.models.utils.actions_toolcall_response import BASH_TOOL_RESPONSE_API
+from minisweagent.models.utils.actions_toolcall_response import SHELL_TOOL_RESPONSE_API
 
 
 def test_response_api_model_basic_query():
@@ -22,7 +22,7 @@ def test_response_api_model_basic_query():
         mock_response = Mock()
         mock_response.id = "resp_123"
         mock_response.output = [
-            {"type": "function_call", "call_id": "call_abc", "name": "bash", "arguments": '{"command": "echo test"}'}
+            {"type": "function_call", "call_id": "call_abc", "name": "shell", "arguments": '{"command": "echo test"}'}
         ]
         mock_response.model_dump.return_value = {
             "id": "resp_123",
@@ -36,7 +36,7 @@ def test_response_api_model_basic_query():
 
         assert result["extra"]["actions"] == [{"command": "echo test", "tool_call_id": "call_abc"}]
         mock_client.responses.create.assert_called_once_with(
-            model="gpt-5-mini", input=messages, tools=[BASH_TOOL_RESPONSE_API]
+            model="gpt-5-mini", input=messages, tools=[SHELL_TOOL_RESPONSE_API]
         )
 
 
@@ -54,7 +54,7 @@ def test_response_api_model_stateless_flattens_response():
         mock_response = Mock()
         mock_response.id = "resp_456"
         mock_response.output = [
-            {"type": "function_call", "call_id": "call_2", "name": "bash", "arguments": '{"command": "echo second"}'}
+            {"type": "function_call", "call_id": "call_2", "name": "shell", "arguments": '{"command": "echo second"}'}
         ]
         mock_response.model_dump.return_value = {"id": "resp_456", "output": mock_response.output}
         mock_client.responses.create.return_value = mock_response
@@ -68,7 +68,7 @@ def test_response_api_model_stateless_flattens_response():
                     {
                         "type": "function_call",
                         "call_id": "call_1",
-                        "name": "bash",
+                        "name": "shell",
                         "arguments": '{"command": "echo first"}',
                     },
                 ],
@@ -83,7 +83,7 @@ def test_response_api_model_stateless_flattens_response():
         # Verify that response objects are flattened and extra is stripped
         expected_input = [
             {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "first"}]},
-            {"type": "function_call", "call_id": "call_1", "name": "bash", "arguments": '{"command": "echo first"}'},
+            {"type": "function_call", "call_id": "call_1", "name": "shell", "arguments": '{"command": "echo first"}'},
             {"type": "function_call_output", "call_id": "call_1", "output": "first"},
             {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "second"}]},
         ]
@@ -104,8 +104,8 @@ def test_response_api_model_multiple_tool_calls():
         mock_response = Mock()
         mock_response.id = "resp_789"
         mock_response.output = [
-            {"type": "function_call", "call_id": "call_1", "name": "bash", "arguments": '{"command": "echo first"}'},
-            {"type": "function_call", "call_id": "call_2", "name": "bash", "arguments": '{"command": "echo second"}'},
+            {"type": "function_call", "call_id": "call_1", "name": "shell", "arguments": '{"command": "echo first"}'},
+            {"type": "function_call", "call_id": "call_2", "name": "shell", "arguments": '{"command": "echo second"}'},
         ]
         mock_response.model_dump.return_value = {
             "id": "resp_789",
@@ -137,7 +137,7 @@ def test_response_api_model_cost_tracking():
         mock_response = Mock()
         mock_response.id = "resp_cost"
         mock_response.output = [
-            {"type": "function_call", "call_id": "call_cost", "name": "bash", "arguments": '{"command": "echo cost"}'}
+            {"type": "function_call", "call_id": "call_cost", "name": "shell", "arguments": '{"command": "echo cost"}'}
         ]
         mock_response.model_dump.return_value = {"id": "resp_cost", "output": mock_response.output}
         mock_client.responses.create.return_value = mock_response
@@ -166,7 +166,7 @@ def test_response_api_model_zero_cost_assertion():
         mock_response = Mock()
         mock_response.id = "resp_zero"
         mock_response.output = [
-            {"type": "function_call", "call_id": "call_zero", "name": "bash", "arguments": '{"command": "echo test"}'}
+            {"type": "function_call", "call_id": "call_zero", "name": "shell", "arguments": '{"command": "echo test"}'}
         ]
         mock_response.model_dump.return_value = {"id": "resp_zero", "output": mock_response.output}
         mock_client.responses.create.return_value = mock_response
@@ -192,7 +192,7 @@ def test_response_api_model_with_model_kwargs():
         mock_response = Mock()
         mock_response.id = "resp_kwargs"
         mock_response.output = [
-            {"type": "function_call", "call_id": "call_kw", "name": "bash", "arguments": '{"command": "echo kwargs"}'}
+            {"type": "function_call", "call_id": "call_kw", "name": "shell", "arguments": '{"command": "echo kwargs"}'}
         ]
         mock_response.model_dump.return_value = {"id": "resp_kwargs", "output": mock_response.output}
         mock_client.responses.create.return_value = mock_response
@@ -230,7 +230,7 @@ def test_response_api_model_retry_on_rate_limit():
                 {
                     "type": "function_call",
                     "call_id": "call_retry",
-                    "name": "bash",
+                    "name": "shell",
                     "arguments": '{"command": "echo Success after retry"}',
                 }
             ]

--- a/tests/models/test_truncation_finish_reason.py
+++ b/tests/models/test_truncation_finish_reason.py
@@ -6,6 +6,7 @@ import pytest
 from minisweagent.exceptions import FormatError
 from minisweagent.models.utils.actions_text import parse_regex_actions
 from minisweagent.models.utils.actions_toolcall_response import (
+    SHELL_TOOL_RESPONSE_API,
     finish_reason_from_responses_api,
     parse_toolcall_actions_response,
 )
@@ -54,6 +55,20 @@ class TestRegexActionsTemplateKwargs:
 
 
 class TestResponseActionsTemplateKwargs:
+    def test_shell_tool_call(self):
+        assert SHELL_TOOL_RESPONSE_API["name"] == "shell"
+        assert parse_toolcall_actions_response(
+            [
+                {
+                    "type": "function_call",
+                    "call_id": "call_1",
+                    "name": "shell",
+                    "arguments": '{"command": "echo hello"}',
+                }
+            ],
+            format_error_template="{{ error }}",
+        ) == [{"command": "echo hello", "tool_call_id": "call_1"}]
+
     def test_finish_reason_reported_on_no_tool_calls(self):
         with pytest.raises(FormatError) as exc:
             parse_toolcall_actions_response(


### PR DESCRIPTION
## Summary

Follow-up to #870: renames the model-facing command tool from `bash` to `shell` in the tool-call schema.

- expose the tool to models as `shell` instead of `bash`
- strict rename: the parser only accepts `shell` (the old name isn't a persisted contract — nothing re-parses saved trajectories)
- update the prompt/error-template lines that reference the tool by name
- runtime interpreter configs such as `["bash", "-c"]` stay unchanged, since those describe the actual shell used to execute commands

## Tests

`python -m pytest tests/models/test_actions_toolcall.py tests/models/test_truncation_finish_reason.py tests/models/test_litellm_model.py tests/models/test_portkey_model.py tests/models/test_portkey_response_model.py`