### PR TITLE
fix(env): handle ProcessLookupError in local env timeout kill

### DIFF
--- a/src/minisweagent/environments/local.py
+++ b/src/minisweagent/environments/local.py
@@ -86,7 +86,10 @@ def _run(command: str, cwd: str, env: dict[str, str], timeout: int) -> subproces
     try:
         stdout, _ = process.communicate(timeout=timeout)
     except subprocess.TimeoutExpired:
-        os.killpg(process.pid, signal.SIGKILL) if os.name == "posix" else process.kill()
+        try:
+            os.killpg(process.pid, signal.SIGKILL) if os.name == "posix" else process.kill()
+        except ProcessLookupError:
+            pass  # Process group already exited between timeout and kill.
         stdout, _ = process.communicate()
         raise subprocess.TimeoutExpired(command, timeout, output=stdout)
     return subprocess.CompletedProcess(command, process.returncode, stdout=stdout)

--- a/tests/environments/test_local.py
+++ b/tests/environments/test_local.py
@@ -135,6 +135,22 @@ def test_local_environment_timeout():
 
 
 @pytest.mark.skipif(os.name == "nt", reason="process groups are POSIX-specific")
+def test_local_environment_timeout_killpg_race_captures_output():
+    """When os.killpg raises ProcessLookupError (process group already exited
+    between the timeout and the kill), communicate() must still run so partial
+    output is captured and TimeoutExpired is raised (not ProcessLookupError)."""
+    import subprocess
+
+    from minisweagent.environments.local import _run
+
+    with patch("minisweagent.environments.local.os.killpg", side_effect=ProcessLookupError):
+        with pytest.raises(subprocess.TimeoutExpired) as exc_info:
+            _run("echo partial_output; sleep 5", os.getcwd(), dict(os.environ), timeout=1)
+
+    assert "partial_output" in (exc_info.value.output or "")
+
+
+@pytest.mark.skipif(os.name == "nt", reason="process groups are POSIX-specific")
 def test_local_environment_timeout_kills_child_process():
     """Test that timeout kills shell-spawned child processes."""
     with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
## Problem

When a command times out in the local environment, `_run` calls `os.killpg(process.pid, signal.SIGKILL)` to kill the process group. If the process group has already exited between `communicate(timeout=...)` raising `TimeoutExpired` and the `killpg` call (a race condition), `killpg` raises `ProcessLookupError`.

This causes two problems:
1. **Resource leak + lost output:** the subsequent `process.communicate()` (which drains the stdout pipe) is skipped, leaking the file descriptor and losing the partial output that was already buffered.
2. **Wrong exception type:** the caller receives `ProcessLookupError` instead of `TimeoutExpired`. Since `ProcessLookupError` has no `output` attribute, the partial output is irrecoverably lost (`getattr(e, "output", None)` returns `None`).

## Solution

Wrap the `killpg`/`kill` call in `try/except ProcessLookupError: pass` so that `communicate()` always runs and the partial output is captured in the `TimeoutExpired` exception.

## Changes

- `src/minisweagent/environments/local.py`: wrap the kill call in `try/except ProcessLookupError`.
- `tests/environments/test_local.py`: add `test_local_environment_timeout_killpg_race_captures_output` (POSIX-only) that mocks `os.killpg` to raise `ProcessLookupError` and asserts partial output is still captured.

## Testing

- New test passes on Linux: `pytest tests/environments/test_local.py -k "timeout or killpg_race"` → **4 passed** (including the new test + existing timeout tests, no regression).
- `ruff check` clean on changed files.
- The test is POSIX-only (`@pytest.mark.skipif(os.name == "nt")`) since `os.killpg` is POSIX-specific.
