### PR TITLE
fix(config): read config files as UTF-8 regardless of locale

### DIFF
--- a/src/minisweagent/config/__init__.py
+++ b/src/minisweagent/config/__init__.py
@@ -58,7 +58,7 @@ def get_config_from_spec(config_spec: str | Path) -> dict:
     if isinstance(config_spec, str) and "=" in config_spec:
         return _key_value_spec_to_nested_dict(config_spec)
     path = get_config_path(config_spec)
-    return yaml.safe_load(path.read_text())
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
 
 
 __all__ = ["builtin_config_dir", "get_config_path", "get_config_from_spec", "_key_value_spec_to_nested_dict"]

--- a/tests/config/test_init.py
+++ b/tests/config/test_init.py
@@ -1,5 +1,9 @@
 """Tests for minisweagent.config.__init__."""
 
+import os
+import subprocess
+import sys
+
 import pytest
 
 from minisweagent.config import (
@@ -105,6 +109,25 @@ class TestGetConfigFromSpec:
         config_file.write_text("key: value\nnumber: 42")
         result = get_config_from_spec(config_file)
         assert result == {"key": "value", "number": 42}
+
+    def test_loads_utf8_yaml_regardless_of_locale(self, tmp_path):
+        # subprocess under a C/ascii locale: read_text() with no encoding= would crash or garble a UTF-8 config
+        config_file = tmp_path / "unicode.yaml"
+        config_file.write_text("system_template: a — b", encoding="utf-8")
+        env = {
+            **os.environ,
+            "LC_ALL": "C",
+            "LANG": "C",
+            "PYTHONUTF8": "0",
+            "PYTHONCOERCECLOCALE": "0",
+            "MSWEA_SILENT_STARTUP": "1",
+        }
+        code = (
+            "from minisweagent.config import get_config_from_spec; "
+            f"assert len(get_config_from_spec(r'{config_file}')['system_template']) == 5"
+        )
+        result = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, env=env)
+        assert result.returncode == 0, result.stderr
 
 
 _ALL_BUILTIN_CONFIGS = list(builtin_config_dir.rglob("*.yaml"))


### PR DESCRIPTION
## Summary

`get_config_from_spec` loaded config files with `path.read_text()`, which decodes using the ambient locale codec. The shipped `programbench.yaml` contains a UTF-8 em dash, so under a C/ascii locale (common in CI and minimal containers) the read raises `UnicodeDecodeError` and the run crashes at startup; on a Windows cp1252 console it silently mis-decodes the prompt. Read configs as UTF-8 so loading no longer depends on the ambient locale.

## Test plan

- Added `test_loads_utf8_yaml_regardless_of_locale`: runs a subprocess under `LC_ALL=C` / `PYTHONUTF8=0`, writes a UTF-8 config containing an em dash, and asserts it parses. Fails on the old code (`UnicodeDecodeError`), passes with the fix.
- `uv run pytest tests/config/test_init.py` -> 38 passed.
