### PR TITLE
fix(models): don't mask malformed tool-call errors as truncation

### DIFF
--- a/src/minisweagent/config/benchmarks/programbench.yaml
+++ b/src/minisweagent/config/benchmarks/programbench.yaml
@@ -257,7 +257,7 @@ model:
     </IMPORTANT>
     {%- endif %}
   format_error_template: |
-    {% if finish_reason is defined and finish_reason in ["length", "tool_calls"] -%}
+    {% if finish_reason is defined and (finish_reason == "length" or (finish_reason == "tool_calls" and not has_tool_calls)) -%}
     Your previous response reached the output token limit (finish_reason={{ finish_reason }}) before you produced a tool call, so it was cut off. Respond more concisely and finish with exactly one bash tool call. If you need to think more, do so briefly.
     {%- else -%}
     Tool call error:

--- a/src/minisweagent/config/benchmarks/swebench.yaml
+++ b/src/minisweagent/config/benchmarks/swebench.yaml
@@ -157,7 +157,7 @@ model:
     </output_tail>
     {%- endif -%}
   format_error_template: |
-    {% if finish_reason is defined and finish_reason in ["length", "tool_calls"] -%}
+    {% if finish_reason is defined and (finish_reason == "length" or (finish_reason == "tool_calls" and not has_tool_calls)) -%}
     Your previous response reached the output token limit (finish_reason={{ finish_reason }}) before you produced a tool call, so it was cut off. Respond more concisely and finish with exactly one bash tool call. If you need to think more, do so briefly.
     {%- else -%}
     Tool call error:

--- a/src/minisweagent/config/mini.yaml
+++ b/src/minisweagent/config/mini.yaml
@@ -127,7 +127,7 @@ model:
     }
     {%- endif -%}
   format_error_template: |
-    {% if finish_reason is defined and finish_reason in ["length", "tool_calls"] -%}
+    {% if finish_reason is defined and (finish_reason == "length" or (finish_reason == "tool_calls" and not has_tool_calls)) -%}
     Your previous response reached the output token limit (finish_reason={{ finish_reason }}) before you produced a tool call, so it was cut off. Respond more concisely and finish with exactly one bash tool call. If you need to think more, do so briefly.
     {%- else -%}
     Tool call error:

--- a/src/minisweagent/models/utils/actions_toolcall.py
+++ b/src/minisweagent/models/utils/actions_toolcall.py
@@ -44,6 +44,7 @@ def parse_toolcall_actions(
                 "content": Template(format_error_template, undefined=StrictUndefined).render(
                     error="No tool calls found in the response. Every response MUST include at least one tool call.",
                     actions=[],
+                    has_tool_calls=False,
                     **template_kwargs,
                 ),
                 "extra": {"interrupt_type": "FormatError"},
@@ -66,7 +67,7 @@ def parse_toolcall_actions(
                 {
                     "role": "user",
                     "content": Template(format_error_template, undefined=StrictUndefined).render(
-                        actions=[], error=error_msg.strip(), **template_kwargs
+                        actions=[], error=error_msg.strip(), has_tool_calls=True, **template_kwargs
                     ),
                     "extra": {"interrupt_type": "FormatError"},
                 }

--- a/src/minisweagent/models/utils/actions_toolcall_response.py
+++ b/src/minisweagent/models/utils/actions_toolcall_response.py
@@ -79,6 +79,7 @@ def parse_toolcall_actions_response(
         error_text = Template(format_error_template, undefined=StrictUndefined).render(
             error="No tool calls found in the response. Every response MUST include at least one tool call.",
             actions=[],
+            has_tool_calls=False,
             **template_kwargs,
         )
         raise FormatError(_format_error_message(error_text))
@@ -96,7 +97,7 @@ def parse_toolcall_actions_response(
             error_msg += "Missing 'command' argument in bash tool call."
         if error_msg:
             error_text = Template(format_error_template, undefined=StrictUndefined).render(
-                error=error_msg.strip(), actions=[], **template_kwargs
+                error=error_msg.strip(), actions=[], has_tool_calls=True, **template_kwargs
             )
             raise FormatError(_format_error_message(error_text))
         actions.append({"command": args["command"], "tool_call_id": tool_call.get("call_id") or tool_call.get("id")})

--- a/tests/models/test_truncation_finish_reason.py
+++ b/tests/models/test_truncation_finish_reason.py
@@ -1,16 +1,32 @@
 """finish_reason is threaded into format_error_template across the parse utilities, so a config can
 report a max_tokens truncation as "cut off" instead of a misleading format error."""
 
+from unittest.mock import MagicMock
+
 import pytest
 
 from minisweagent.exceptions import FormatError
 from minisweagent.models.utils.actions_text import parse_regex_actions
+from minisweagent.models.utils.actions_toolcall import parse_toolcall_actions
 from minisweagent.models.utils.actions_toolcall_response import (
     finish_reason_from_responses_api,
     parse_toolcall_actions_response,
 )
 
 _TEMPLATE = "{% if finish_reason == 'length' %}cut off{% else %}{{ error }}{% endif %}"
+# mirrors the production condition in mini.yaml / swebench.yaml / programbench.yaml
+_TOOLCALL_TEMPLATE = (
+    "{% if finish_reason is defined and (finish_reason == 'length' "
+    "or (finish_reason == 'tool_calls' and not has_tool_calls)) %}cut off{% else %}{{ error }}{% endif %}"
+)
+
+
+def _toolcall(name: str, arguments: str):
+    tc = MagicMock()
+    tc.function.name = name
+    tc.function.arguments = arguments
+    tc.id = "call_1"
+    return tc
 
 
 class TestFinishReasonFromResponsesApi:
@@ -60,3 +76,45 @@ class TestResponseActionsTemplateKwargs:
                 [], format_error_template=_TEMPLATE, template_kwargs={"finish_reason": "length"}
             )
         assert exc.value.messages[0]["content"][0]["text"] == "cut off"
+
+
+class TestHasToolCallsDistinction:
+    """A malformed tool call (finish_reason == "tool_calls") must surface the real error, while an
+    empty payload with the same finish_reason is the truncation case -- the has_tool_calls flag lets
+    the template tell them apart (issue #894)."""
+
+    def test_malformed_toolcall_with_tool_calls_reason_shows_real_error(self):
+        with pytest.raises(FormatError) as exc:
+            parse_toolcall_actions(
+                [_toolcall("shell", '{"command": "ls"}')],
+                format_error_template=_TOOLCALL_TEMPLATE,
+                template_kwargs={"finish_reason": "tool_calls"},
+            )
+        assert "Unknown tool 'shell'" in exc.value.messages[0]["content"]
+
+    def test_empty_payload_with_tool_calls_reason_reports_truncation(self):
+        with pytest.raises(FormatError) as exc:
+            parse_toolcall_actions(
+                [], format_error_template=_TOOLCALL_TEMPLATE, template_kwargs={"finish_reason": "tool_calls"}
+            )
+        assert exc.value.messages[0]["content"] == "cut off"
+
+    def test_malformed_toolcall_with_length_reason_still_reports_truncation(self):
+        # arguments cut off mid-JSON is a genuine truncation, so keep the "cut off" hint
+        with pytest.raises(FormatError) as exc:
+            parse_toolcall_actions(
+                [_toolcall("bash", "{not json")],
+                format_error_template=_TOOLCALL_TEMPLATE,
+                template_kwargs={"finish_reason": "length"},
+            )
+        assert exc.value.messages[0]["content"] == "cut off"
+
+    def test_response_parser_passes_has_tool_calls(self):
+        # the Responses API parser shares these templates, so it must supply has_tool_calls too
+        with pytest.raises(FormatError) as exc:
+            parse_toolcall_actions_response(
+                [{"type": "function_call", "call_id": "c1", "name": "shell", "arguments": "{}"}],
+                format_error_template=_TOOLCALL_TEMPLATE,
+                template_kwargs={"finish_reason": "tool_calls"},
+            )
+        assert "Unknown tool 'shell'" in exc.value.messages[0]["content"][0]["text"]


### PR DESCRIPTION
## Problem

Fixes #894.

When a model returns a tool call that *exists but is malformed* (wrong tool name, missing `command`, invalid JSON arguments), the response has `finish_reason == "tool_calls"`. The `format_error_template` truncation branch — `finish_reason in ["length", "tool_calls"]` — treated this identically to a genuine `length` truncation, so the real validation error (e.g. `Unknown tool 'shell'.`) was swapped for a *"your response reached the output token limit… so it was cut off"* message and **never shown to the model**. The model then keeps retrying blindly until it hits `max_consecutive_format_errors` and exits with `RepeatedFormatError`.

The root issue: `"tool_calls"` is a *normal* completion reason. It should only imply truncation when the payload is **empty** (a provider quirk where a truncated response is reported as `tool_calls` with no actual call). When a tool call *was* produced, `finish_reason` is irrelevant and the real error should surface.

## Fix

Expose an explicit `has_tool_calls` flag from both tool-call parsers (`actions_toolcall.py` and `actions_toolcall_response.py`), so the template can distinguish the two cases instead of overloading `finish_reason`:

- empty payload → `has_tool_calls=False`
- malformed tool call → `has_tool_calls=True`

The three tool-call configs (`mini.yaml`, `swebench.yaml`, `programbench.yaml`) now condition on:

```jinja
{% if finish_reason is defined and (finish_reason == "length" or (finish_reason == "tool_calls" and not has_tool_calls)) -%}
```

### Behavior

| case | before | after |
|---|---|---|
| malformed tool call + `tool_calls` | truncation msg (bug) | **real error** ✓ |
| empty payload + `tool_calls` | truncation msg | truncation msg ✓ |
| args cut off mid-JSON + `length` | truncation msg | truncation msg ✓ |
| no tool call + `stop` | real error | real error ✓ |

## Notes

- Both parsers are updated because they **share** these config templates (Responses API path included), so the template variable must always be supplied.
- The text-based configs (`default.yaml`, `mini_textbased.yaml`, `swebench_xml.yaml`, `swebench_backticks.yaml`) are intentionally left unchanged: they render via `actions_text.py`, never see `finish_reason == "tool_calls"`, and referencing `has_tool_calls` there would crash under `StrictUndefined`.
- Compatibility: old configs keep working (the extra kwarg is ignored). A new config only requires the new framework — the mismatch is a non-issue since configs ship inside the package alongside the parsers.

Added regression tests in `tests/models/test_truncation_finish_reason.py` covering all four cases plus the Responses API parser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)