### PR TITLE
🐛 fix(models): retry OpenRouter error responses

### DIFF
--- a/src/minisweagent/models/openrouter_model.py
+++ b/src/minisweagent/models/openrouter_model.py
@@ -98,6 +98,7 @@ class OpenRouterModel:
         for attempt in retry(logger=logger, abort_exceptions=self.abort_exceptions):
             with attempt:
                 response = self._query(self._prepare_messages_for_api(messages), **kwargs)
+                self._validate_response(response)
         cost_output = self._calculate_cost(response)
         GLOBAL_MODEL_STATS.add(cost_output["cost"])
         try:
@@ -114,6 +115,16 @@ class OpenRouterModel:
             "timestamp": time.time(),
         }
         return message
+
+    def _validate_response(self, response: dict) -> None:
+        choices = response.get("choices") if isinstance(response, dict) else None
+        if (
+            not isinstance(choices, list)
+            or not choices
+            or not isinstance(choices[0], dict)
+            or not isinstance(choices[0].get("message"), dict)
+        ):
+            raise OpenRouterAPIError(f"Invalid chat completion response: {response}")
 
     def _calculate_cost(self, response) -> dict[str, float]:
         usage = response.get("usage", {})

--- a/tests/models/test_openrouter_model.py
+++ b/tests/models/test_openrouter_model.py
@@ -1,0 +1,51 @@
+from unittest.mock import patch
+
+import pytest
+from tenacity import Retrying, stop_after_attempt, wait_none
+
+from minisweagent.models.openrouter_model import OpenRouterAPIError, OpenRouterModel
+
+
+@pytest.mark.parametrize(
+    ("response",),  # noqa: PT006
+    [
+        ({"error": {"message": "Provider returned an error"}},),
+        ({"choices": []},),
+        ({"choices": [{}]},),
+        ({"choices": "invalid"},),
+        ([],),
+    ],
+)
+def test_openrouter_model_rejects_invalid_chat_completion(response) -> None:
+    model = OpenRouterModel(model_name="test/model")
+
+    with pytest.raises(OpenRouterAPIError, match="Invalid chat completion response"):
+        model._validate_response(response)
+
+
+def test_openrouter_model_retries_invalid_chat_completion() -> None:
+    model = OpenRouterModel(model_name="test/model")
+    valid_response = {
+        "choices": [
+            {
+                "message": {
+                    "tool_calls": [
+                        {"id": "call_1", "function": {"name": "bash", "arguments": '{"command": "echo ok"}'}}
+                    ]
+                },
+                "finish_reason": "tool_calls",
+            }
+        ],
+        "usage": {"cost": 0.1},
+    }
+
+    with (
+        patch.object(model, "_query", side_effect=[{"error": {"message": "temporary error"}}, valid_response]) as query,
+        patch(
+            "minisweagent.models.openrouter_model.retry",
+            return_value=Retrying(stop=stop_after_attempt(2), wait=wait_none(), reraise=True),
+        ),
+    ):
+        assert model.query([{"role": "user", "content": "hello"}])["extra"]["response"] == valid_response
+
+    assert query.call_count == 2


### PR DESCRIPTION
Occasionally, OpenRouter with GPT models returns a response containing an error:

```json
{
  "error": {
    "message": "This content was flagged for possible cybersecurity risk...",
    "code": 502
  }
}
```

Because the response has no `choices`, mini-swe-agent throws `KeyError: 'choices'` outside its retry loop.

This change validates the response inside the retry boundary and raises `OpenRouterAPIError`, allowing the existing retry policy to handle it.