### PR TITLE
enh(run): defer prompt_toolkit import until prompting

### DIFF
--- a/src/minisweagent/run/mini.py
+++ b/src/minisweagent/run/mini.py
@@ -12,7 +12,6 @@ from rich.console import Console
 
 from minisweagent import global_config_dir
 from minisweagent.agents import get_agent
-from minisweagent.agents.utils.prompt_user import _multiline_prompt
 from minisweagent.config import builtin_config_dir, get_config_from_spec
 from minisweagent.environments import get_environment
 from minisweagent.models import get_model
@@ -92,6 +91,8 @@ def main(
     config = recursive_merge(*configs)
 
     if (run_task := config.get("run", {}).get("task", UNSET)) is UNSET:
+        from minisweagent.agents.utils.prompt_user import _multiline_prompt
+
         console.print("[bold yellow]What do you want to do?")
         run_task = _multiline_prompt()
         console.print("[bold green]Got that, thanks![/bold green]")

--- a/tests/run/test_cli_integration.py
+++ b/tests/run/test_cli_integration.py
@@ -15,6 +15,22 @@ def strip_ansi_codes(text: str) -> str:
     return ansi_escape.sub("", text)
 
 
+def test_import_mini_does_not_load_prompt_toolkit():
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import sys; import minisweagent.run.mini; "
+            'print(any(name == "prompt_toolkit" or name.startswith("prompt_toolkit.") for name in sys.modules))',
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=True,
+    )
+    assert result.stdout.splitlines()[-1] == "False"
+
+
 def test_configure_if_first_time_called():
     """Test that configure_if_first_time is called when running mini main."""
     with (
@@ -98,7 +114,7 @@ def test_mini_calls_prompt_when_no_task_provided():
     """Test that mini calls prompt when no task is provided."""
     with (
         patch("minisweagent.run.mini.configure_if_first_time"),
-        patch("minisweagent.run.mini._multiline_prompt") as mock_prompt,
+        patch("minisweagent.agents.utils.prompt_user._multiline_prompt") as mock_prompt,
         patch("minisweagent.run.mini.get_agent") as mock_get_agent,
         patch("minisweagent.run.mini.get_model") as mock_get_model,
         patch("minisweagent.run.mini.get_environment") as mock_get_env,


### PR DESCRIPTION
## Summary

- defer the private multiline prompt import until the existing no-task branch needs it
- add a fresh-interpreter regression test for the import boundary
- preserve interactive prompting by patching the helper at its defining module

This follows a review suggestion from [PR #749](https://github.com/SWE-agent/mini-swe-agent/pull/749#discussion_r2830036314).

## Performance

Measured with Python 3.11 in the same isolated environment, using 31 fresh interpreters after 5 warmups:

| Revision | Median `minisweagent.run.mini` import |
| --- | ---: |
| Current main (`e187bcb2`) | 118.993 ms |
| This change | 54.976 ms |

That is a 53.80% reduction (2.16x faster) for fresh module import.

This benchmark measures fresh module import only. CLI help is a correctness gate, not a separately timed metric. It does not measure normal default agent execution, and `prompt_toolkit` remains a required dependency.

## Validation

- new subprocess regression test fails on pristine main and passes with this change
- focused tests: 133 passed
- full suite: 568 passed, 51 skipped
- `uvx ruff check --fix .`
- `uvx ruff format --check .`
- `pylint minisweagent/ --errors-only`
- `git diff --check`

## Autoresearch

Supplementary autoresearch: [20-step public dashboard](https://dashboard.weco.ai/share/xdYZU-szc1VeENC-ALLiGDytSoC-bo7Q).