### PR TITLE
fix: extract hardcoded tools list into overridable _tools() method

### DIFF
--- a/src/minisweagent/models/litellm_model.py
+++ b/src/minisweagent/models/litellm_model.py
@@ -61,12 +61,16 @@ class LitellmModel:
         if self.config.litellm_model_registry and Path(self.config.litellm_model_registry).is_file():
             litellm.utils.register_model(json.loads(Path(self.config.litellm_model_registry).read_text()))
 
+    def _tools(self) -> list[dict]:
+        """Tool schemas offered to the model. Override to expose more than bash."""
+        return [BASH_TOOL]
+
     def _query(self, messages: list[dict[str, str]], **kwargs):
         try:
             return litellm.completion(
                 model=self.config.model_name,
                 messages=messages,
-                tools=[BASH_TOOL],
+                tools=self._tools(),
                 **(self.config.model_kwargs | kwargs),
             )
         except litellm.exceptions.AuthenticationError as e:

--- a/tests/models/test_litellm_model.py
+++ b/tests/models/test_litellm_model.py
@@ -38,6 +38,38 @@ class TestLitellmModel:
         mock_completion.assert_called_once()
         assert mock_completion.call_args.kwargs["tools"] == [BASH_TOOL]
 
+    def test_tools_defaults_to_bash_tool(self):
+        model = LitellmModel(model_name="gpt-4")
+        assert model._tools() == [BASH_TOOL]
+
+    @patch("minisweagent.models.litellm_model.litellm.completion")
+    @patch("minisweagent.models.litellm_model.litellm.cost_calculator.completion_cost")
+    def test_tools_override_changes_tools_passed_to_completion(self, mock_cost, mock_completion):
+        custom_tool = {
+            "type": "function",
+            "function": {
+                "name": "custom",
+                "parameters": {"type": "object", "properties": {}, "required": []},
+            },
+        }
+
+        class CustomModel(LitellmModel):
+            def _tools(self):
+                return [BASH_TOOL, custom_tool]
+
+        tool_call = MagicMock()
+        tool_call.function.name = "bash"
+        tool_call.function.arguments = '{"command": "echo test"}'
+        tool_call.id = "call_1"
+        mock_completion.return_value = _mock_litellm_response([tool_call])
+        mock_cost.return_value = 0.001
+
+        model = CustomModel(model_name="gpt-4")
+        model.query([{"role": "user", "content": "test"}])
+
+        mock_completion.assert_called_once()
+        assert mock_completion.call_args.kwargs["tools"] == [BASH_TOOL, custom_tool]
+
     @patch("minisweagent.models.litellm_model.litellm.completion")
     @patch("minisweagent.models.litellm_model.litellm.cost_calculator.completion_cost")
     def test_parse_actions_valid_tool_call(self, mock_cost, mock_completion):


### PR DESCRIPTION
## Summary

`LitellmModel._query` passes `tools=[BASH_TOOL]` as a literal, so the only way to give the model additional tools is to copy the entire `_query` body into a subclass and keep that copy in sync on every release.

This PR extracts the tool list into a `_tools()` method that defaults to `[BASH_TOOL]`, preserving existing behavior while allowing subclasses to override just the tool list.

## Changes

- Add `_tools()` method to `LitellmModel` returning `[BASH_TOOL]` by default
- Update `_query` to call `self._tools()` instead of using the literal
- Add `test_tools_defaults_to_bash_tool` — verifies the default
- Add `test_tools_override_changes_tools_passed_to_completion` — verifies that overriding `_tools()` in a subclass changes what reaches `litellm.completion`

All existing tests pass (the 4 pre-existing `portkey_ai` import failures are unrelated — missing optional dependency).

Closes #889