### PR TITLE
fix(agents): reset task state for each run

### DIFF
--- a/src/minisweagent/agents/default.py
+++ b/src/minisweagent/agents/default.py
@@ -89,6 +89,10 @@ class DefaultAgent:
         """Run step() until agent is finished. Returns dictionary with exit_status, submission keys."""
         self.extra_template_vars |= {"task": task, **kwargs}
         self.messages = []
+        self.cost = 0.0
+        self.n_calls = 0
+        self.n_consecutive_format_errors = 0
+        self._start_time = time.time()
         self.add_messages(
             self.model.format_message(role="system", content=self._render_template(self.config.system_template)),
             self.model.format_message(role="user", content=self._render_template(self.config.instance_template)),

--- a/tests/agents/test_default.py
+++ b/tests/agents/test_default.py
@@ -169,6 +169,26 @@ def test_step_limit_enforcement(model_factory):
     assert agent.n_calls == 1
 
 
+def test_run_resets_limits(model_factory):
+    factory, config = model_factory
+    agent = DefaultAgent(
+        model=factory(
+            [
+                ("First command", [{"command": "echo 'first'"}]),
+                ("Second command", [{"command": "echo 'second'"}]),
+            ]
+        ),
+        env=LocalEnvironment(),
+        **{**config, "step_limit": 1, "cost_limit": 0},
+    )
+
+    assert agent.run("First task")["exit_status"] == "LimitsExceeded"
+    assert agent.run("Second task")["exit_status"] == "LimitsExceeded"
+    assert "Second command" in str(agent.messages)
+    assert agent.n_calls == 1
+    assert agent.cost == 1.0
+
+
 def test_cost_limit_enforcement(model_factory):
     """Test agent stops when cost limit is reached."""
     factory, config = model_factory


### PR DESCRIPTION
Fixes #909

Reset per-task counters, cost, format-error state, and elapsed-time tracking when a reused `DefaultAgent` starts `run()`. The regression exercises two consecutive tasks and verifies each receives a fresh step budget.
