### PR TITLE
Add Atlas Cloud model adapter

### DIFF
--- a/src/minisweagent/models/__init__.py
+++ b/src/minisweagent/models/__init__.py
@@ -76,6 +76,7 @@ def get_model_name(input_model_name: str | None = None, config: dict | None = No
 
 
 _MODEL_CLASS_MAPPING = {
+    "atlascloud": "minisweagent.models.atlascloud_model.AtlasCloudModel",
     "litellm": "minisweagent.models.litellm_model.LitellmModel",
     "litellm_textbased": "minisweagent.models.litellm_textbased_model.LitellmTextbasedModel",
     "litellm_response": "minisweagent.models.litellm_response_model.LitellmResponseModel",
@@ -106,6 +107,11 @@ def get_model_class(model_name: str, model_class: str = "") -> type:
         except (ValueError, ImportError, AttributeError):
             msg = f"Unknown model class: {model_class} (resolved to {full_path}, available: {_MODEL_CLASS_MAPPING})"
             raise ValueError(msg)
+
+    if model_name.startswith("atlascloud/"):
+        from minisweagent.models.atlascloud_model import AtlasCloudModel
+
+        return AtlasCloudModel
 
     # Default to LitellmModel
     from minisweagent.models.litellm_model import LitellmModel

--- a/src/minisweagent/models/atlascloud_model.py
+++ b/src/minisweagent/models/atlascloud_model.py
@@ -19,7 +19,9 @@ class AtlasCloudModel(LitellmModel):
             msg = "ATLASCLOUD_API_KEY is required for Atlas Cloud models."
             raise ValueError(msg)
 
-        api_base = model_kwargs.pop("api_base", None) or os.getenv("ATLASCLOUD_API_BASE", "https://api.atlascloud.ai/v1")
+        api_base = model_kwargs.pop("api_base", None) or os.getenv(
+            "ATLASCLOUD_API_BASE", "https://api.atlascloud.ai/v1"
+        )
         kwargs["model_name"] = self._to_litellm_model_name(kwargs["model_name"])
         kwargs.setdefault("cost_tracking", "ignore_errors")
         kwargs["model_kwargs"] = {

--- a/src/minisweagent/models/atlascloud_model.py
+++ b/src/minisweagent/models/atlascloud_model.py
@@ -1,0 +1,34 @@
+import os
+from typing import Literal
+
+from minisweagent.models.litellm_model import LitellmModel, LitellmModelConfig
+
+
+class AtlasCloudModelConfig(LitellmModelConfig):
+    cost_tracking: Literal["default", "ignore_errors"] = "ignore_errors"
+    """Atlas Cloud model costs are not in LiteLLM's bundled registry, so default to zero-cost tracking."""
+
+
+class AtlasCloudModel(LitellmModel):
+    """Atlas Cloud OpenAI-compatible model adapter."""
+
+    def __init__(self, **kwargs):
+        model_kwargs = dict(kwargs.pop("model_kwargs", {}))
+        api_key = model_kwargs.pop("api_key", None) or os.getenv("ATLASCLOUD_API_KEY")
+        if not api_key:
+            msg = "ATLASCLOUD_API_KEY is required for Atlas Cloud models."
+            raise ValueError(msg)
+
+        api_base = model_kwargs.pop("api_base", None) or os.getenv("ATLASCLOUD_API_BASE", "https://api.atlascloud.ai/v1")
+        kwargs["model_name"] = self._to_litellm_model_name(kwargs["model_name"])
+        kwargs.setdefault("cost_tracking", "ignore_errors")
+        kwargs["model_kwargs"] = {
+            "api_key": api_key,
+            "api_base": api_base,
+            **model_kwargs,
+        }
+        super().__init__(config_class=AtlasCloudModelConfig, **kwargs)
+
+    @staticmethod
+    def _to_litellm_model_name(model_name: str) -> str:
+        return f"openai/{model_name.removeprefix('atlascloud/')}"

--- a/tests/models/test_atlascloud_model.py
+++ b/tests/models/test_atlascloud_model.py
@@ -1,0 +1,57 @@
+import os
+from unittest.mock import patch
+
+import pytest
+
+from minisweagent.models import get_model
+from minisweagent.models.atlascloud_model import AtlasCloudModel
+
+
+def test_atlascloud_model_configures_litellm_openai_compatible_kwargs():
+    with patch.dict(os.environ, {"ATLASCLOUD_API_KEY": "test-key"}, clear=True):
+        model = AtlasCloudModel(model_name="atlascloud/qwen/qwen3.5-flash", model_kwargs={"temperature": 0.2})
+
+    assert model.config.model_name == "openai/qwen/qwen3.5-flash"
+    assert model.config.model_kwargs["api_key"] == "test-key"
+    assert model.config.model_kwargs["api_base"] == "https://api.atlascloud.ai/v1"
+    assert model.config.model_kwargs["temperature"] == 0.2
+    assert model.config.cost_tracking == "ignore_errors"
+
+
+def test_atlascloud_model_uses_custom_api_base_and_key_from_config():
+    with patch.dict(os.environ, {}, clear=True):
+        model = AtlasCloudModel(
+            model_name="atlascloud/deepseek-ai/deepseek-v4-pro",
+            model_kwargs={"api_key": "config-key", "api_base": "https://example.test/v1"},
+        )
+
+    assert model.config.model_name == "openai/deepseek-ai/deepseek-v4-pro"
+    assert model.config.model_kwargs["api_key"] == "config-key"
+    assert model.config.model_kwargs["api_base"] == "https://example.test/v1"
+
+
+def test_atlascloud_model_requires_api_key():
+    with patch.dict(os.environ, {}, clear=True):
+        with pytest.raises(ValueError, match="ATLASCLOUD_API_KEY"):
+            AtlasCloudModel(model_name="atlascloud/qwen/qwen3.5-flash")
+
+
+def test_atlascloud_query_passes_openai_compatible_kwargs_to_litellm():
+    with patch.dict(os.environ, {"ATLASCLOUD_API_KEY": "test-key"}, clear=True):
+        model = AtlasCloudModel(model_name="atlascloud/qwen/qwen3.5-flash")
+
+    with patch("minisweagent.models.litellm_model.litellm.completion") as mock_completion:
+        model._query([{"role": "user", "content": "hello"}], max_tokens=32)
+
+    call_kwargs = mock_completion.call_args.kwargs
+    assert call_kwargs["model"] == "openai/qwen/qwen3.5-flash"
+    assert call_kwargs["api_key"] == "test-key"
+    assert call_kwargs["api_base"] == "https://api.atlascloud.ai/v1"
+    assert call_kwargs["max_tokens"] == 32
+
+
+def test_get_model_selects_atlascloud_adapter_for_prefix():
+    with patch.dict(os.environ, {"ATLASCLOUD_API_KEY": "test-key"}, clear=True):
+        model = get_model("atlascloud/qwen/qwen3.5-flash")
+
+    assert isinstance(model, AtlasCloudModel)

--- a/tests/models/test_init.py
+++ b/tests/models/test_init.py
@@ -76,6 +76,13 @@ class TestGetModelClass:
 
         assert get_model_class("any-model", "litellm_response") == LitellmResponseModel
 
+    def test_atlascloud_model_selection(self):
+        """Test that atlascloud/* model names use the Atlas Cloud adapter."""
+        from minisweagent.models.atlascloud_model import AtlasCloudModel
+
+        assert get_model_class("atlascloud/qwen/qwen3.5-flash") == AtlasCloudModel
+        assert get_model_class("any-model", "atlascloud") == AtlasCloudModel
+
 
 class TestGetModel:
     def test_config_deep_copy(self):


### PR DESCRIPTION
## Summary
- add an `AtlasCloudModel` adapter for Atlas Cloud's OpenAI-compatible API
- route `atlascloud/...` model names through the adapter and support explicit `model_class: atlascloud`
- inject `ATLASCLOUD_API_KEY` and optional `ATLASCLOUD_API_BASE` into LiteLLM's OpenAI-compatible call path
- add focused tests for adapter configuration, query kwargs, key validation, and model class selection

## Validation
- `PYTHONPATH=src .venv/bin/python -m pytest -q tests/models/test_atlascloud_model.py tests/models/test_init.py::TestGetModelClass` (10 passed; existing pytest config warnings)
- `python3 -m compileall src/minisweagent/models/atlascloud_model.py src/minisweagent/models/__init__.py tests/models/test_atlascloud_model.py tests/models/test_init.py`
- `uv run --no-project --with ruff ruff check src/minisweagent/models/atlascloud_model.py src/minisweagent/models/__init__.py tests/models/test_atlascloud_model.py tests/models/test_init.py`
- `git diff --check`
- live Atlas model catalog check confirmed `qwen/qwen3.5-flash` and `deepseek-ai/deepseek-v4-pro`

No README, sponsor, logo, credits, or partner promotion changes.
