### PR TITLE
fix(agents): count billed calls that fail to parse against cost_limit

### DIFF
--- a/src/minisweagent/agents/default.py
+++ b/src/minisweagent/agents/default.py
@@ -98,6 +98,8 @@ class DefaultAgent:
                 self.step()
                 self.n_consecutive_format_errors = 0  # reset on any clean step
             except FormatError as e:
+                # The call was billed before parsing failed, so query() never got to charge it.
+                self.cost += e.messages[0].get("extra", {}).get("cost", 0.0)
                 self.n_consecutive_format_errors += 1
                 if 0 < self.config.max_consecutive_format_errors <= self.n_consecutive_format_errors:
                     self.add_messages(

--- a/src/minisweagent/models/litellm_model.py
+++ b/src/minisweagent/models/litellm_model.py
@@ -84,10 +84,11 @@ class LitellmModel:
                 response = self._query(self._prepare_messages_for_api(messages), **kwargs)
         cost_output = self._calculate_cost(response)
         GLOBAL_MODEL_STATS.add(cost_output["cost"])
-        # Note: all model.query() implementations must persist the response on FormatError.
+        # Note: all model.query() implementations must persist the response and cost on FormatError.
         try:
             actions = self._parse_actions(response)
         except FormatError as e:
+            e.messages[0]["extra"].update(cost_output)
             try:
                 e.messages[0]["extra"]["response"] = response.model_dump(mode="json")
             except Exception:

--- a/src/minisweagent/models/litellm_response_model.py
+++ b/src/minisweagent/models/litellm_response_model.py
@@ -58,6 +58,7 @@ class LitellmResponseModel(LitellmModel):
         try:
             actions = self._parse_actions(response)
         except FormatError as e:
+            e.messages[0]["extra"].update(cost_output)
             # hasattr guard: litellm.responses() returns a pydantic object, but tests
             # may inject a plain dict; dict(response) is the correct fallback in that case.
             # Inner try: if serialization itself fails, repr() guarantees the key is always set.

--- a/src/minisweagent/models/openrouter_model.py
+++ b/src/minisweagent/models/openrouter_model.py
@@ -103,6 +103,7 @@ class OpenRouterModel:
         try:
             actions = self._parse_actions(response)
         except FormatError as e:
+            e.messages[0]["extra"].update(cost_output)
             # dict(response) is a shallow copy; the original response object is not mutated.
             e.messages[0]["extra"]["response"] = dict(response)
             raise

--- a/src/minisweagent/models/openrouter_response_model.py
+++ b/src/minisweagent/models/openrouter_response_model.py
@@ -91,6 +91,7 @@ class OpenRouterResponseModel(OpenRouterModel):
         try:
             actions = self._parse_actions(response)
         except FormatError as e:
+            e.messages[0]["extra"].update(cost_output)
             e.messages[0]["extra"]["response"] = dict(response)
             raise
         message = dict(response)

--- a/src/minisweagent/models/portkey_model.py
+++ b/src/minisweagent/models/portkey_model.py
@@ -110,6 +110,7 @@ class PortkeyModel:
         try:
             actions = self._parse_actions(response)
         except FormatError as e:
+            e.messages[0]["extra"].update(cost_output)
             try:
                 e.messages[0]["extra"]["response"] = response.model_dump(mode="json")
             except Exception:

--- a/src/minisweagent/models/portkey_response_model.py
+++ b/src/minisweagent/models/portkey_response_model.py
@@ -102,6 +102,7 @@ class PortkeyResponseAPIModel:
         try:
             actions = self._parse_actions(response)
         except FormatError as e:
+            e.messages[0]["extra"].update(cost_output)
             # hasattr guard: Portkey returns a pydantic object, but tests may inject a plain dict.
             # Inner try: if serialization itself fails, repr() guarantees the key is always set.
             try:

--- a/src/minisweagent/models/requesty_model.py
+++ b/src/minisweagent/models/requesty_model.py
@@ -108,6 +108,7 @@ class RequestyModel:
         try:
             actions = self._parse_actions(response)
         except FormatError as e:
+            e.messages[0]["extra"].update(cost_output)
             # dict(response) is a shallow copy; the original response object is not mutated.
             e.messages[0]["extra"]["response"] = dict(response)
             raise

--- a/tests/agents/test_default.py
+++ b/tests/agents/test_default.py
@@ -6,6 +6,7 @@ import yaml
 from minisweagent.agents.default import DefaultAgent
 from minisweagent.environments.local import LocalEnvironment
 from minisweagent.exceptions import FormatError
+from minisweagent.models import GLOBAL_MODEL_STATS
 from minisweagent.models.test_models import (
     DeterministicModel,
     DeterministicResponseAPIToolcallModel,
@@ -509,3 +510,35 @@ def test_format_error_counter_resets_on_success(toolcall_config):
     info = agent.run("Test counter reset")
     assert info["exit_status"] == "Submitted"
     assert info["submission"] == "ok\n"
+
+
+class _BilledFormatErrorModel(DeterministicToolcallModel):
+    """Bills the call and then fails to parse it, the way the real model classes do: the cost is
+    charged to the global stats and persisted on the FormatError before it propagates."""
+
+    def query(self, messages, **kwargs):
+        GLOBAL_MODEL_STATS.add(self.config.cost_per_call)
+        raise FormatError(
+            {
+                "role": "user",
+                "content": "No tool calls found in the response.",
+                "extra": {"interrupt_type": "FormatError", "cost": self.config.cost_per_call},
+            }
+        )
+
+
+def test_format_errors_count_against_cost_limit(toolcall_config, reset_global_stats):
+    """Turns that fail to parse are still billed, so they have to count against cost_limit.
+    step_limit is only a backstop here: if the format-error path stopped charging, the run would
+    run on to that limit with agent.cost still at zero."""
+    agent = DefaultAgent(
+        model=_BilledFormatErrorModel(outputs=[], cost_per_call=1.0),
+        env=LocalEnvironment(),
+        **{**toolcall_config, "cost_limit": 2.5, "step_limit": 8, "max_consecutive_format_errors": 0},
+    )
+
+    info = agent.run("Test billed format errors")
+    assert info["exit_status"] == "LimitsExceeded"
+    assert agent.n_calls == 3
+    assert agent.cost == 3.0
+    assert agent.cost == GLOBAL_MODEL_STATS.cost

--- a/tests/models/test_format_error_response_persistence.py
+++ b/tests/models/test_format_error_response_persistence.py
@@ -92,7 +92,7 @@ def test_litellm_model_format_error_persists_response() -> None:
 
     with (
         patch.object(LitellmModel, "_query", return_value=response),
-        patch.object(LitellmModel, "_calculate_cost", return_value={"cost": 0.0}),
+        patch.object(LitellmModel, "_calculate_cost", return_value={"cost": 0.02}),
     ):
         with pytest.raises(FormatError) as excinfo:
             model.query([{"role": "user", "content": "hi"}])
@@ -103,6 +103,7 @@ def test_litellm_model_format_error_persists_response() -> None:
     # model_dump(mode='json') was used: result must be JSON-serialisable
     json.dumps(extra["response"])
     response.model_dump.assert_any_call(mode="json")
+    assert extra["cost"] == 0.02
 
 
 # --------------------------------------------------------------------------- #
@@ -122,7 +123,7 @@ def test_litellm_response_model_format_error_persists_response_with_model_dump()
 
     with (
         patch.object(LitellmResponseModel, "_query", return_value=response),
-        patch.object(LitellmResponseModel, "_calculate_cost", return_value={"cost": 0.0}),
+        patch.object(LitellmResponseModel, "_calculate_cost", return_value={"cost": 0.02}),
     ):
         with pytest.raises(FormatError) as excinfo:
             model.query([{"role": "user", "content": "hi"}])
@@ -131,6 +132,7 @@ def test_litellm_response_model_format_error_persists_response_with_model_dump()
     assert "response" in extra
     assert extra["response"] == serialized
     json.dumps(extra["response"])  # JSON-serialisable
+    assert extra["cost"] == 0.02
 
 
 def test_litellm_response_model_format_error_persists_response_plain_dict_fallback() -> None:
@@ -165,7 +167,7 @@ def test_openrouter_model_format_error_persists_response() -> None:
 
     with (
         patch.object(OpenRouterModel, "_query", return_value=response),
-        patch.object(OpenRouterModel, "_calculate_cost", return_value={"cost": 0.0}),
+        patch.object(OpenRouterModel, "_calculate_cost", return_value={"cost": 0.02}),
     ):
         with pytest.raises(FormatError) as excinfo:
             model.query([{"role": "user", "content": "hi"}])
@@ -174,6 +176,7 @@ def test_openrouter_model_format_error_persists_response() -> None:
     assert "response" in extra
     assert extra["response"] == response  # plain dict round-trip
     assert extra["response"] is not response  # must be a copy, not the same object
+    assert extra["cost"] == 0.02
 
 
 # --------------------------------------------------------------------------- #
@@ -189,7 +192,7 @@ def test_openrouter_response_model_format_error_persists_response() -> None:
 
     with (
         patch.object(OpenRouterResponseModel, "_query", return_value=response),
-        patch.object(OpenRouterResponseModel, "_calculate_cost", return_value={"cost": 0.0}),
+        patch.object(OpenRouterResponseModel, "_calculate_cost", return_value={"cost": 0.02}),
     ):
         with pytest.raises(FormatError) as excinfo:
             model.query([{"role": "user", "content": "hi"}])
@@ -198,6 +201,7 @@ def test_openrouter_response_model_format_error_persists_response() -> None:
     assert "response" in extra
     assert extra["response"] == response
     assert extra["response"] is not response  # must be a copy, not the same object
+    assert extra["cost"] == 0.02
 
 
 # --------------------------------------------------------------------------- #
@@ -220,7 +224,7 @@ def test_portkey_model_format_error_persists_response(monkeypatch: pytest.Monkey
 
     with (
         patch.object(PortkeyModel, "_query", return_value=response),
-        patch.object(PortkeyModel, "_calculate_cost", return_value={"cost": 0.0}),
+        patch.object(PortkeyModel, "_calculate_cost", return_value={"cost": 0.02}),
     ):
         with pytest.raises(FormatError) as excinfo:
             model.query([{"role": "user", "content": "hi"}])
@@ -230,6 +234,7 @@ def test_portkey_model_format_error_persists_response(monkeypatch: pytest.Monkey
     assert extra["response"], "response payload empty — fix not applied"
     json.dumps(extra["response"])  # JSON-serialisable
     response.model_dump.assert_any_call(mode="json")
+    assert extra["cost"] == 0.02
 
 
 # --------------------------------------------------------------------------- #
@@ -253,7 +258,7 @@ def test_portkey_response_model_format_error_persists_response_with_model_dump(
 
     with (
         patch.object(PortkeyResponseAPIModel, "_query", return_value=response),
-        patch.object(PortkeyResponseAPIModel, "_calculate_cost", return_value={"cost": 0.0}),
+        patch.object(PortkeyResponseAPIModel, "_calculate_cost", return_value={"cost": 0.02}),
     ):
         with pytest.raises(FormatError) as excinfo:
             model.query([{"role": "user", "content": "hi"}])
@@ -262,6 +267,7 @@ def test_portkey_response_model_format_error_persists_response_with_model_dump(
     assert "response" in extra
     assert extra["response"] == serialized
     json.dumps(extra["response"])  # JSON-serialisable
+    assert extra["cost"] == 0.02
 
 
 # --------------------------------------------------------------------------- #
@@ -286,6 +292,7 @@ def test_requesty_model_format_error_persists_response() -> None:
     assert "response" in extra
     assert extra["response"] == response
     assert extra["response"] is not response  # must be a copy, not the same object
+    assert extra["cost"] == 0.01
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary

A model call is billed before its response is parsed. In `litellm_model.py` `query()` runs `_calculate_cost()` and `GLOBAL_MODEL_STATS.add(...)`, then `_parse_actions()` can raise `FormatError` and re-raise, so `query()` never returns. The agent's `self.cost += ...` on the next line never runs, `run()` catches the error and loops, and the budget check at `default.py:130` never sees the spend. A run keeps paying past its `cost_limit`, and `instance_cost` in the trajectory comes out low.

The cost was never lost, only stranded: `GLOBAL_MODEL_STATS` had the right total the whole time while `agent.cost` did not.

`litellm_model.py:87` already says "all model.query() implementations must persist the response on FormatError". This extends that contract to the cost and reads it from the `except FormatError` handler `run()` already has, so no new control flow is introduced.

Fixes #914.

## Changes

- Each of the seven `query()` implementations adds `e.messages[0]["extra"].update(cost_output)` inside the `except FormatError` block that already persists the response.
- `DefaultAgent.run()` adds the persisted cost in its existing handler.
- The contract note in `litellm_model.py` now reads "response and cost".

Production change is 11 lines. The rest is tests.

## Test plan

- [x] New `test_format_errors_count_against_cost_limit` in `tests/agents/test_default.py`: an agent whose turns all fail to parse stops at `cost_limit` after 3 calls instead of running to `step_limit`. Removing the `default.py` change makes it fail with `8 != 3`.
- [x] The seven existing per-model tests in `tests/models/test_format_error_response_persistence.py` now also assert the persisted cost. Verified by mutation: deleting the new line from any one of the seven fails exactly one test. Before this, deleting it from `litellm_response_model.py` failed nothing.
- [x] Full suite 333 passed vs 332 on `main`, with the same pre-existing failures on both (Windows `prompt_toolkit`, docker and network tests).
- [x] `ruff check` and `ruff format --check` clean.

## Notes

Scope is deliberately narrow. `FormatError` is the only path that bills and then keeps looping, so it is the only one that leaks. The other handlers in `run()` are terminal.

This does not overlap #910, which resets `self.cost` between `run()` invocations. That is the same field for a different reason, and the two changes touch different parts of `run()`.

One unrelated thing I noticed: `test_format_error_counter_resets_on_success` currently fails on a clean `main` with an `IndexError` from an exhausted `outputs` list. Not touched here, but worth a look.
