### PR TITLE
fix(models): stop retrying context window errors

### DIFF
--- a/src/minisweagent/models/openrouter_model.py
+++ b/src/minisweagent/models/openrouter_model.py
@@ -15,6 +15,7 @@ from minisweagent.models.utils.actions_toolcall import (
     parse_toolcall_actions,
 )
 from minisweagent.models.utils.anthropic_utils import _reorder_anthropic_thinking_blocks
+from minisweagent.models.utils.api_errors import is_context_window_error
 from minisweagent.models.utils.cache_control import set_cache_control
 from minisweagent.models.utils.openai_multimodal import expand_multimodal_content
 from minisweagent.models.utils.retry import retry
@@ -44,6 +45,10 @@ class OpenRouterAPIError(Exception):
     """Custom exception for OpenRouter API errors."""
 
 
+class OpenRouterContextWindowError(OpenRouterAPIError):
+    """OpenRouter rejected a request that exceeds the model context window."""
+
+
 class OpenRouterAuthenticationError(Exception):
     """Custom exception for OpenRouter authentication errors."""
 
@@ -53,7 +58,11 @@ class OpenRouterRateLimitError(Exception):
 
 
 class OpenRouterModel:
-    abort_exceptions: list[type[Exception]] = [OpenRouterAuthenticationError, KeyboardInterrupt]
+    abort_exceptions: list[type[Exception]] = [
+        OpenRouterAuthenticationError,
+        OpenRouterContextWindowError,
+        KeyboardInterrupt,
+    ]
 
     def __init__(self, **kwargs):
         self.config = OpenRouterModelConfig(**kwargs)
@@ -84,6 +93,8 @@ class OpenRouterModel:
                 raise OpenRouterAuthenticationError(error_msg) from e
             elif response.status_code == 429:
                 raise OpenRouterRateLimitError("Rate limit exceeded") from e
+            elif is_context_window_error(response):
+                raise OpenRouterContextWindowError(f"HTTP {response.status_code}: {response.text}") from e
             else:
                 raise OpenRouterAPIError(f"HTTP {response.status_code}: {response.text}") from e
         except requests.exceptions.RequestException as e:

--- a/src/minisweagent/models/openrouter_response_model.py
+++ b/src/minisweagent/models/openrouter_response_model.py
@@ -9,6 +9,7 @@ from minisweagent.models import GLOBAL_MODEL_STATS
 from minisweagent.models.openrouter_model import (
     OpenRouterAPIError,
     OpenRouterAuthenticationError,
+    OpenRouterContextWindowError,
     OpenRouterModel,
     OpenRouterModelConfig,
     OpenRouterRateLimitError,
@@ -19,6 +20,7 @@ from minisweagent.models.utils.actions_toolcall_response import (
     format_toolcall_observation_messages,
     parse_toolcall_actions_response,
 )
+from minisweagent.models.utils.api_errors import is_context_window_error
 from minisweagent.models.utils.retry import retry
 
 logger = logging.getLogger("openrouter_response_model")
@@ -62,6 +64,8 @@ class OpenRouterResponseModel(OpenRouterModel):
                 raise OpenRouterAuthenticationError(error_msg) from e
             elif response.status_code == 429:
                 raise OpenRouterRateLimitError("Rate limit exceeded") from e
+            elif is_context_window_error(response):
+                raise OpenRouterContextWindowError(f"HTTP {response.status_code}: {response.text}") from e
             else:
                 raise OpenRouterAPIError(f"HTTP {response.status_code}: {response.text}") from e
         except requests.exceptions.RequestException as e:

--- a/src/minisweagent/models/openrouter_textbased_model.py
+++ b/src/minisweagent/models/openrouter_textbased_model.py
@@ -6,11 +6,13 @@ import requests
 from minisweagent.models.openrouter_model import (
     OpenRouterAPIError,
     OpenRouterAuthenticationError,
+    OpenRouterContextWindowError,
     OpenRouterModel,
     OpenRouterModelConfig,
     OpenRouterRateLimitError,
 )
 from minisweagent.models.utils.actions_text import format_observation_messages, parse_regex_actions
+from minisweagent.models.utils.api_errors import is_context_window_error
 
 logger = logging.getLogger("openrouter_textbased_model")
 
@@ -52,6 +54,8 @@ class OpenRouterTextbasedModel(OpenRouterModel):
                 raise OpenRouterAuthenticationError(error_msg) from e
             elif response.status_code == 429:
                 raise OpenRouterRateLimitError("Rate limit exceeded") from e
+            elif is_context_window_error(response):
+                raise OpenRouterContextWindowError(f"HTTP {response.status_code}: {response.text}") from e
             else:
                 raise OpenRouterAPIError(f"HTTP {response.status_code}: {response.text}") from e
         except requests.exceptions.RequestException as e:

--- a/src/minisweagent/models/requesty_model.py
+++ b/src/minisweagent/models/requesty_model.py
@@ -15,6 +15,7 @@ from minisweagent.models.utils.actions_toolcall import (
     parse_toolcall_actions,
 )
 from minisweagent.models.utils.anthropic_utils import _reorder_anthropic_thinking_blocks
+from minisweagent.models.utils.api_errors import is_context_window_error
 from minisweagent.models.utils.cache_control import set_cache_control
 from minisweagent.models.utils.openai_multimodal import expand_multimodal_content
 from minisweagent.models.utils.retry import retry
@@ -44,6 +45,10 @@ class RequestyAPIError(Exception):
     pass
 
 
+class RequestyContextWindowError(RequestyAPIError):
+    """Requesty rejected a request that exceeds the model context window."""
+
+
 class RequestyAuthenticationError(Exception):
     """Custom exception for Requesty authentication errors."""
 
@@ -57,7 +62,11 @@ class RequestyRateLimitError(Exception):
 
 
 class RequestyModel:
-    abort_exceptions: list[type[Exception]] = [RequestyAuthenticationError, KeyboardInterrupt]
+    abort_exceptions: list[type[Exception]] = [
+        RequestyAuthenticationError,
+        RequestyContextWindowError,
+        KeyboardInterrupt,
+    ]
 
     def __init__(self, **kwargs):
         self.config = RequestyModelConfig(**kwargs)
@@ -89,6 +98,8 @@ class RequestyModel:
                 raise RequestyAuthenticationError(error_msg) from e
             elif response.status_code == 429:
                 raise RequestyRateLimitError("Rate limit exceeded") from e
+            elif is_context_window_error(response):
+                raise RequestyContextWindowError(f"HTTP {response.status_code}: {response.text}") from e
             else:
                 raise RequestyAPIError(f"HTTP {response.status_code}: {response.text}") from e
         except requests.exceptions.RequestException as e:

--- a/src/minisweagent/models/utils/api_errors.py
+++ b/src/minisweagent/models/utils/api_errors.py
@@ -1,0 +1,45 @@
+"""Utilities for classifying model API errors."""
+
+import re
+
+import requests
+
+_CONTEXT_WINDOW_ERROR_CODE = "context_length_exceeded"
+_CONTEXT_WINDOW_ERROR_MESSAGES = (
+    "context length exceeded",
+    "context window exceeded",
+    "context limit exceeded",
+    "exceeds the context window",
+    "maximum context length",
+    "context window exceeds limit",
+)
+
+
+def is_context_window_error(response: requests.Response) -> bool:
+    """Return whether a 400 response reports a context window overflow."""
+    if response.status_code != 400:
+        return False
+    try:
+        body = response.json()
+    except requests.exceptions.JSONDecodeError:
+        body = {}
+    body = body if isinstance(body, dict) else {}
+    error = body.get("error", {})
+    error = error if isinstance(error, dict) else {}
+    metadata = error.get("metadata", {})
+    metadata = metadata if isinstance(metadata, dict) else {}
+    codes = (
+        body.get("error_type"),
+        error.get("code"),
+        error.get("type"),
+        error.get("error_type"),
+        metadata.get("error_type"),
+        metadata.get("provider_code"),
+    )
+    if _CONTEXT_WINDOW_ERROR_CODE in codes:
+        return True
+    message = error.get("message")
+    if not isinstance(message, str):
+        return False
+    message = " ".join(re.findall(r"[a-z0-9]+", message.lower()))
+    return any(fragment in message for fragment in _CONTEXT_WINDOW_ERROR_MESSAGES)

--- a/tests/models/test_context_window_errors.py
+++ b/tests/models/test_context_window_errors.py
@@ -1,0 +1,135 @@
+import json
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import pytest
+
+from minisweagent.models.openrouter_model import OpenRouterAPIError, OpenRouterContextWindowError, OpenRouterModel
+from minisweagent.models.openrouter_response_model import OpenRouterResponseModel
+from minisweagent.models.openrouter_textbased_model import OpenRouterTextbasedModel
+from minisweagent.models.requesty_model import RequestyAPIError, RequestyContextWindowError, RequestyModel
+
+
+@pytest.fixture
+def error_server():
+    state = {"requests": 0, "status": 400, "payload": {}}
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self):
+            state["requests"] += 1
+            body = json.dumps(state["payload"]).encode()
+            self.send_response(state["status"])
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, *args):
+            pass
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    yield server, state
+    server.shutdown()
+    server.server_close()
+    thread.join()
+
+
+@pytest.mark.parametrize(
+    ("model_class", "error_class", "payload"),
+    [
+        pytest.param(
+            OpenRouterModel,
+            OpenRouterContextWindowError,
+            {"error": {"message": "provider error", "metadata": {"error_type": "context_length_exceeded"}}},
+            id="openrouter-metadata-error-type",
+        ),
+        pytest.param(
+            OpenRouterTextbasedModel,
+            OpenRouterContextWindowError,
+            {"error": {"message": "provider error", "type": "context_length_exceeded"}},
+            id="openrouter-error-type",
+        ),
+        pytest.param(
+            OpenRouterResponseModel,
+            OpenRouterContextWindowError,
+            {"error_type": "context_length_exceeded", "error": {"code": "invalid_prompt"}},
+            id="openrouter-responses-error-type",
+        ),
+        pytest.param(
+            RequestyModel,
+            RequestyContextWindowError,
+            {"error": {"message": "provider error", "code": "context_length_exceeded"}},
+            id="requesty-error-code",
+        ),
+        pytest.param(
+            RequestyModel,
+            RequestyContextWindowError,
+            {"error": {"message": "This model has a maximum context length of 128000 tokens"}},
+            id="requesty-message-fallback",
+        ),
+    ],
+)
+def test_context_window_errors_abort_without_retry(error_server, monkeypatch, model_class, error_class, payload):
+    server, state = error_server
+    state["payload"] = payload
+    monkeypatch.setenv("MSWEA_MODEL_RETRY_STOP_AFTER_ATTEMPT", "3")
+    monkeypatch.setattr(time, "sleep", lambda _: None)
+    model = model_class(model_name="test")
+    model._api_url = f"http://127.0.0.1:{server.server_port}/v1/chat/completions"
+
+    with pytest.raises(error_class, match="HTTP 400") as exc_info:
+        model.query([{"role": "user", "content": "oversized"}])
+
+    assert type(exc_info.value) is error_class
+    assert state["requests"] == 1
+
+
+@pytest.mark.parametrize(
+    ("model_class", "error_class", "status", "payload"),
+    [
+        pytest.param(
+            OpenRouterModel,
+            OpenRouterAPIError,
+            400,
+            {"error": {"code": "invalid_request", "message": "model is missing"}},
+            id="openrouter-generic-400",
+        ),
+        pytest.param(
+            OpenRouterModel,
+            OpenRouterAPIError,
+            500,
+            {"error": {"message": "server error"}},
+            id="openrouter-500",
+        ),
+        pytest.param(
+            RequestyModel,
+            RequestyAPIError,
+            400,
+            {"error": {"code": "token_limit_exceeded", "message": "token budget exceeded"}},
+            id="requesty-unrelated-400",
+        ),
+        pytest.param(
+            RequestyModel,
+            RequestyAPIError,
+            500,
+            {"error": {"message": "server error"}},
+            id="requesty-500",
+        ),
+    ],
+)
+def test_other_api_errors_remain_retryable(error_server, monkeypatch, model_class, error_class, status, payload):
+    server, state = error_server
+    state.update({"status": status, "payload": payload})
+    monkeypatch.setenv("MSWEA_MODEL_RETRY_STOP_AFTER_ATTEMPT", "2")
+    monkeypatch.setattr(time, "sleep", lambda _: None)
+    model = model_class(model_name="test")
+    model._api_url = f"http://127.0.0.1:{server.server_port}/v1/chat/completions"
+
+    with pytest.raises(error_class) as exc_info:
+        model.query([{"role": "user", "content": "test"}])
+
+    assert type(exc_info.value) is error_class
+    assert state["requests"] == 2


### PR DESCRIPTION
## Summary
- Classify only HTTP 400 context-window overflows using canonical provider error fields and a conservative message fallback.
- Raise provider-specific API-error subclasses across the OpenRouter tool-call, text-based, and Responses adapters, plus Requesty, so permanent failures abort immediately.
- Preserve existing retries for unrelated 400 responses, transient 5xx responses, and network errors.

Closes #921

## Testing
- Real local HTTP-server tests verify context overflows make one request while other API errors retain the configured retry count.
- `pytest -q tests/models/test_context_window_errors.py tests/models/test_openrouter_textbased_model.py` (16 passed)
- `pytest -q -n auto` (552 passed, 76 skipped)
- Ruff check and format validation on all changed files
- All applicable Python pre-commit hooks on all changed files