### PR TITLE
fix(models): stop retrying permanent context overflow errors

### DIFF
--- a/src/minisweagent/models/openrouter_model.py
+++ b/src/minisweagent/models/openrouter_model.py
@@ -15,6 +15,7 @@ from minisweagent.models.utils.actions_toolcall import (
     parse_toolcall_actions,
 )
 from minisweagent.models.utils.anthropic_utils import _reorder_anthropic_thinking_blocks
+from minisweagent.models.utils.api_errors import is_context_length_error
 from minisweagent.models.utils.cache_control import set_cache_control
 from minisweagent.models.utils.openai_multimodal import expand_multimodal_content
 from minisweagent.models.utils.retry import retry
@@ -44,6 +45,10 @@ class OpenRouterAPIError(Exception):
     """Custom exception for OpenRouter API errors."""
 
 
+class OpenRouterContextLengthError(OpenRouterAPIError):
+    """Custom exception for permanent context length errors."""
+
+
 class OpenRouterAuthenticationError(Exception):
     """Custom exception for OpenRouter authentication errors."""
 
@@ -53,7 +58,11 @@ class OpenRouterRateLimitError(Exception):
 
 
 class OpenRouterModel:
-    abort_exceptions: list[type[Exception]] = [OpenRouterAuthenticationError, KeyboardInterrupt]
+    abort_exceptions: list[type[Exception]] = [
+        OpenRouterAuthenticationError,
+        OpenRouterContextLengthError,
+        KeyboardInterrupt,
+    ]
 
     def __init__(self, **kwargs):
         self.config = OpenRouterModelConfig(**kwargs)
@@ -84,6 +93,8 @@ class OpenRouterModel:
                 raise OpenRouterAuthenticationError(error_msg) from e
             elif response.status_code == 429:
                 raise OpenRouterRateLimitError("Rate limit exceeded") from e
+            elif is_context_length_error(response.status_code, response.text):
+                raise OpenRouterContextLengthError(f"HTTP {response.status_code}: {response.text}") from e
             else:
                 raise OpenRouterAPIError(f"HTTP {response.status_code}: {response.text}") from e
         except requests.exceptions.RequestException as e:

--- a/src/minisweagent/models/openrouter_response_model.py
+++ b/src/minisweagent/models/openrouter_response_model.py
@@ -9,6 +9,7 @@ from minisweagent.models import GLOBAL_MODEL_STATS
 from minisweagent.models.openrouter_model import (
     OpenRouterAPIError,
     OpenRouterAuthenticationError,
+    OpenRouterContextLengthError,
     OpenRouterModel,
     OpenRouterModelConfig,
     OpenRouterRateLimitError,
@@ -19,6 +20,7 @@ from minisweagent.models.utils.actions_toolcall_response import (
     format_toolcall_observation_messages,
     parse_toolcall_actions_response,
 )
+from minisweagent.models.utils.api_errors import is_context_length_error
 from minisweagent.models.utils.retry import retry
 
 logger = logging.getLogger("openrouter_response_model")
@@ -62,6 +64,8 @@ class OpenRouterResponseModel(OpenRouterModel):
                 raise OpenRouterAuthenticationError(error_msg) from e
             elif response.status_code == 429:
                 raise OpenRouterRateLimitError("Rate limit exceeded") from e
+            elif is_context_length_error(response.status_code, response.text):
+                raise OpenRouterContextLengthError(f"HTTP {response.status_code}: {response.text}") from e
             else:
                 raise OpenRouterAPIError(f"HTTP {response.status_code}: {response.text}") from e
         except requests.exceptions.RequestException as e:

--- a/src/minisweagent/models/openrouter_textbased_model.py
+++ b/src/minisweagent/models/openrouter_textbased_model.py
@@ -6,11 +6,13 @@ import requests
 from minisweagent.models.openrouter_model import (
     OpenRouterAPIError,
     OpenRouterAuthenticationError,
+    OpenRouterContextLengthError,
     OpenRouterModel,
     OpenRouterModelConfig,
     OpenRouterRateLimitError,
 )
 from minisweagent.models.utils.actions_text import format_observation_messages, parse_regex_actions
+from minisweagent.models.utils.api_errors import is_context_length_error
 
 logger = logging.getLogger("openrouter_textbased_model")
 
@@ -52,6 +54,8 @@ class OpenRouterTextbasedModel(OpenRouterModel):
                 raise OpenRouterAuthenticationError(error_msg) from e
             elif response.status_code == 429:
                 raise OpenRouterRateLimitError("Rate limit exceeded") from e
+            elif is_context_length_error(response.status_code, response.text):
+                raise OpenRouterContextLengthError(f"HTTP {response.status_code}: {response.text}") from e
             else:
                 raise OpenRouterAPIError(f"HTTP {response.status_code}: {response.text}") from e
         except requests.exceptions.RequestException as e:

--- a/src/minisweagent/models/requesty_model.py
+++ b/src/minisweagent/models/requesty_model.py
@@ -15,6 +15,7 @@ from minisweagent.models.utils.actions_toolcall import (
     parse_toolcall_actions,
 )
 from minisweagent.models.utils.anthropic_utils import _reorder_anthropic_thinking_blocks
+from minisweagent.models.utils.api_errors import is_context_length_error
 from minisweagent.models.utils.cache_control import set_cache_control
 from minisweagent.models.utils.openai_multimodal import expand_multimodal_content
 from minisweagent.models.utils.retry import retry
@@ -44,6 +45,10 @@ class RequestyAPIError(Exception):
     pass
 
 
+class RequestyContextLengthError(RequestyAPIError):
+    """Custom exception for permanent context length errors."""
+
+
 class RequestyAuthenticationError(Exception):
     """Custom exception for Requesty authentication errors."""
 
@@ -57,7 +62,11 @@ class RequestyRateLimitError(Exception):
 
 
 class RequestyModel:
-    abort_exceptions: list[type[Exception]] = [RequestyAuthenticationError, KeyboardInterrupt]
+    abort_exceptions: list[type[Exception]] = [
+        RequestyAuthenticationError,
+        RequestyContextLengthError,
+        KeyboardInterrupt,
+    ]
 
     def __init__(self, **kwargs):
         self.config = RequestyModelConfig(**kwargs)
@@ -89,6 +98,8 @@ class RequestyModel:
                 raise RequestyAuthenticationError(error_msg) from e
             elif response.status_code == 429:
                 raise RequestyRateLimitError("Rate limit exceeded") from e
+            elif is_context_length_error(response.status_code, response.text):
+                raise RequestyContextLengthError(f"HTTP {response.status_code}: {response.text}") from e
             else:
                 raise RequestyAPIError(f"HTTP {response.status_code}: {response.text}") from e
         except requests.exceptions.RequestException as e:

--- a/src/minisweagent/models/utils/api_errors.py
+++ b/src/minisweagent/models/utils/api_errors.py
@@ -1,0 +1,9 @@
+"""Helpers for classifying provider API errors."""
+
+
+def is_context_length_error(status_code: int, response_text: str) -> bool:
+    """Return whether a 400 response identifies a permanent context overflow."""
+    if status_code != 400:
+        return False
+    response_text = response_text.lower()
+    return "context_length_exceeded" in response_text or "context_window_exceeded" in response_text

--- a/tests/models/test_context_length_retry.py
+++ b/tests/models/test_context_length_retry.py
@@ -1,0 +1,31 @@
+from unittest.mock import Mock, patch
+
+import pytest
+import requests
+
+from minisweagent.models.openrouter_model import OpenRouterContextLengthError, OpenRouterModel
+from minisweagent.models.openrouter_response_model import OpenRouterResponseModel
+from minisweagent.models.openrouter_textbased_model import OpenRouterTextbasedModel
+from minisweagent.models.requesty_model import RequestyContextLengthError, RequestyModel
+
+
+@pytest.mark.parametrize(
+    ("model_class", "error_class"),
+    [
+        (OpenRouterModel, OpenRouterContextLengthError),
+        (OpenRouterTextbasedModel, OpenRouterContextLengthError),
+        (OpenRouterResponseModel, OpenRouterContextLengthError),
+        (RequestyModel, RequestyContextLengthError),
+    ],
+)
+def test_context_length_errors_abort_without_retry(model_class, error_class, monkeypatch):
+    monkeypatch.setenv("MSWEA_MODEL_RETRY_STOP_AFTER_ATTEMPT", "3")
+    model = model_class(model_name="test/model")
+    response = Mock(status_code=400, text='{"error":{"code":"context_length_exceeded"}}')
+    response.raise_for_status.side_effect = requests.exceptions.HTTPError()
+
+    with patch("requests.post", return_value=response) as post:
+        with pytest.raises(error_class):
+            model.query([{"role": "user", "content": "x"}])
+
+    assert post.call_count == 1


### PR DESCRIPTION
## Summary

Fixes #921.

Context-window overflow responses are permanent request errors, but the model retry loop currently treats them like transient provider failures. A single oversized prompt can therefore resend the full history up to ten times before surfacing the original error.

This change:

- classifies the documented `context_length_exceeded` and `context_window_exceeded` 400 responses as non-retryable;
- applies the same behavior to OpenRouter's chat, text, and Responses API models and to Requesty;
- adds a focused regression test that verifies each model makes exactly one request.

## Root cause

Provider-specific model classes only excluded authentication errors and `KeyboardInterrupt` from Tenacity retries. Context overflow was raised as the generic API exception, so the retry policy resent an unchanged request even though retrying cannot reduce its size.

## Validation

- `python -m pytest -q tests/models/test_context_length_retry.py tests/models/test_openrouter_textbased_model.py` — 11 passed
- real local HTTP 400 server reproduction — exactly 1 request
- Ruff format and lint checks — passed
- `python -m compileall -q src/minisweagent/models tests/models/test_context_length_retry.py` — passed

The broader model test collection still has six unrelated failures in tests that import the optional `litellm` dependency; no changed code is involved in those failures.

## Compatibility

Only recognized context-overflow 400 responses change behavior. Authentication, rate-limit, network, and other provider errors keep their existing retry policies.
