### PR TITLE
fix(agents): reset task state for each run

### DIFF
--- a/src/minisweagent/agents/default.py
+++ b/src/minisweagent/agents/default.py
@@ -87,6 +87,10 @@ class DefaultAgent:
 
     def run(self, task: str = "", **kwargs) -> dict:
         """Run step() until agent is finished. Returns dictionary with exit_status, submission keys."""
+        self.cost = 0.0
+        self.n_calls = 0
+        self.n_consecutive_format_errors = 0
+        self._start_time = time.time()
         self.extra_template_vars |= {"task": task, **kwargs}
         self.messages = []
         self.add_messages(

--- a/tests/agents/test_default.py
+++ b/tests/agents/test_default.py
@@ -170,6 +170,38 @@ def test_step_limit_enforcement(model_factory):
     assert agent.n_calls == 1
 
 
+def test_run_resets_task_scoped_limits(model_factory):
+    """Reusing an agent gives each run independent counters and timing."""
+    factory, config = model_factory
+    model = factory(
+        [
+            ("First command", [{"command": "echo first"}]),
+            ("Second command", [{"command": "echo second"}]),
+        ],
+    )
+    agent = DefaultAgent(
+        model=model,
+        env=LocalEnvironment(),
+        **{
+            **config,
+            "step_limit": 1,
+            "wall_time_limit_seconds": 1,
+        },
+    )
+
+    assert agent.run("First task")["exit_status"] == "LimitsExceeded"
+    agent.cost = 100.0
+    agent.n_consecutive_format_errors = 2
+    agent._start_time = 0
+
+    assert agent.run("Second task")["exit_status"] == "LimitsExceeded"
+    assert agent.n_calls == 1
+    assert agent.cost < 100.0
+    assert agent.n_consecutive_format_errors == 0
+    assert agent._start_time > 0
+    assert model.current_index == 1
+
+
 def test_cost_limit_enforcement(model_factory):
     """Test agent stops when cost limit is reached."""
     factory, config = model_factory


### PR DESCRIPTION
Fixes #909.

## Root cause

`DefaultAgent` initializes its step count, cost, consecutive format-error count, and wall-clock start time only in `__init__()`. Although `run()` clears the message history, it keeps those task-scoped values.

Reusing an agent therefore gives the next task the previous task's consumed budget. A second run can stop with `LimitsExceeded` or `TimeExceeded` before making a model call, and stale format errors can contribute to an unrelated task.

## What changed

- Reset `cost`, `n_calls`, and `n_consecutive_format_errors` at the start of every `run()`.
- Start a fresh wall-clock budget for every `run()`.
- Add a regression test that reuses one agent for two tasks, injects stale cost/error/time state between them, and verifies that the second task receives one independent model call.

This keeps instance configuration, model/environment objects, global model statistics, and per-run trajectory serialization unchanged.

## Validation

```text
python -m pytest +  tests/agents/test_default.py::test_step_limit_enforcement +  tests/agents/test_default.py::test_run_resets_task_scoped_limits -q
6 passed

ruff check src/minisweagent/agents/default.py tests/agents/test_default.py
All checks passed!

ruff format --check src/minisweagent/agents/default.py tests/agents/test_default.py
2 files already formatted
```

The six pytest cases cover the text, tool-call, and Responses API deterministic model fixtures. I did not report the entire `test_default.py` file as green on this Windows host because several existing tests depend on Bash output semantics; the focused limit/reset cases are platform-independent and pass.

## Risk and review notes

The behavioral change is intentionally limited to repeated calls to `run()` on the same agent instance. The primary review point is whether all four values are task-scoped; they already describe per-run limits and are emitted as per-instance trajectory statistics, while global accounting remains in `GLOBAL_MODEL_STATS`.
