### PR TITLE
fix(deps): require LiteLLM Gemini signature fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "requests",
     "jinja2",
     "pydantic >= 2.0",  # v2 required for safe mutable default arguments
-    "litellm >= 1.75.5, != 1.82.7, != 1.82.8", # Security: Skip compromised 1.82.7/8; requires 1.75.5+ for GPT-5
+    "litellm >= 1.96.0",  # Requires Gemini thought-signature deduplication from LiteLLM #35004
     "tenacity",
     "rich",
     "python-dotenv",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "requests",
     "jinja2",
     "pydantic >= 2.0",  # v2 required for safe mutable default arguments
-    "litellm >= 1.96.0",  # Requires Gemini thought-signature deduplication from LiteLLM #35004
+    "litellm >= 1.96.0",
     "tenacity",
     "rich",
     "python-dotenv",


### PR DESCRIPTION
## Summary

- raise the LiteLLM floor to 1.96.0, the first stable release containing BerriAI/litellm#35004
- prevent duplicate Gemini thought-signature replay on text and tool-call parts
- avoid doubled reasoning-token context growth and premature context-window exhaustion on Gemini 3 and newer

The previous lower bound still allowed environments to resolve LiteLLM 1.95.0, which predates the upstream fix. This dependency bump replaces the local workaround proposed in #918 with the released upstream implementation.

## Testing

- verified the #918 serialization reproduction against `litellm==1.96.0` emits exactly one signature
- `uv run --isolated --extra dev --extra contree --extra modal pytest -n auto` (568 passed, 51 skipped)
- `git diff --check`