### PR TITLE
feat(agents): session-scoped todos agent (prompt + JSON)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ preds.json
 traj.json
 .claude/**
 .vscode/**
+.mini_todos/
 
 # Created by https://www.toptal.com/developers/gitignore/api/python
 # Edit at https://www.toptal.com/developers/gitignore?templates=python

--- a/src/minisweagent/agents/README.md
+++ b/src/minisweagent/agents/README.md
@@ -2,3 +2,4 @@
 
 * `default.py` - Minimal default agent implementation.
 * `interactive.py` - Extends `default.py` with some minimal human-in-the-loop functionality (confirm actions, etc.).
+* `todos.py` - Extends `interactive.py` with a per-session todo file path for checklist prompts (`mini_todos.yaml`).

--- a/src/minisweagent/agents/__init__.py
+++ b/src/minisweagent/agents/__init__.py
@@ -8,6 +8,7 @@ from minisweagent import Agent, Environment, Model
 _AGENT_MAPPING = {
     "default": "minisweagent.agents.default.DefaultAgent",
     "interactive": "minisweagent.agents.interactive.InteractiveAgent",
+    "todos": "minisweagent.agents.todos.TodosAgent",
 }
 
 

--- a/src/minisweagent/agents/todos.py
+++ b/src/minisweagent/agents/todos.py
@@ -1,0 +1,17 @@
+"""Interactive agent that isolates todo state per run via a unique file path."""
+
+import uuid
+
+from minisweagent.agents.interactive import InteractiveAgent, InteractiveAgentConfig
+
+
+class TodosAgent(InteractiveAgent):
+    """Same as InteractiveAgent, but injects a per-session ``todo_path`` for prompts."""
+
+    def __init__(self, *args, config_class=InteractiveAgentConfig, **kwargs):
+        super().__init__(*args, config_class=config_class, **kwargs)
+
+    def run(self, task: str = "", **kwargs) -> dict:
+        kwargs.setdefault("todo_session_id", uuid.uuid4().hex[:12])
+        kwargs.setdefault("todo_path", f".mini_todos/{kwargs['todo_session_id']}.json")
+        return super().run(task, **kwargs)

--- a/src/minisweagent/config/mini_todos.yaml
+++ b/src/minisweagent/config/mini_todos.yaml
@@ -1,0 +1,188 @@
+agent:
+  # Per-session todo path is injected by TodosAgent as todo_path / todo_session_id.
+  agent_class: todos
+  system_template: |
+    You are a helpful assistant that can interact with a computer.
+  instance_template: |
+    Please solve this issue: {{task}}
+
+    You can execute bash commands and edit files to implement the necessary changes.
+
+    ## Todo tracking (required)
+
+    Persist a checklist in `{{ todo_path }}` (this run's session file only — do not use another path). Create it early (before substantive work), keep it updated as you go, and prefer rewriting the whole file over partial edits.
+
+    Schema:
+
+    ```json
+    {
+      "task": "short echo of the user task",
+      "items": [
+        {"id": "1", "title": "concrete next action", "status": "pending"},
+        {"id": "2", "title": "another action", "status": "in_progress"},
+        {"id": "3", "title": "later action", "status": "done"}
+      ]
+    }
+    ```
+
+    Status values: `pending` | `in_progress` | `done`. Keep at most one `in_progress` item. Do not commit this file. Before submitting, mark finished items `done` (or leave a clear abandoned note in the title).
+
+    Create or update example:
+
+    ```bash
+    mkdir -p "$(dirname '{{ todo_path }}')" && cat <<'EOF' > {{ todo_path }}
+    {
+      "task": "example",
+      "items": [
+        {"id": "1", "title": "Inspect repo layout", "status": "done"},
+        {"id": "2", "title": "Implement fix", "status": "in_progress"},
+        {"id": "3", "title": "Verify with a repro script", "status": "pending"}
+      ]
+    }
+    EOF
+    ```
+
+    ## Recommended Workflow
+
+    This workflow should be done step-by-step so that you can iterate on your changes and any possible problems.
+
+    1. Create `{{ todo_path }}` with a concrete ordered plan for the task
+    2. Analyze the codebase by finding and reading relevant files
+    3. Create a script to reproduce the issue
+    4. Edit the source code to resolve the issue
+    5. Verify your fix works by running your script again
+    6. Test edge cases to ensure your fix is robust
+    7. Update `{{ todo_path }}` statuses, then submit by issuing: `echo COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT`.
+       Do not combine it with any other command. <important>After this command, you cannot continue working on this task.</important>
+
+    ## Command Execution Rules
+
+    You are operating in an environment where
+
+    1. You issue at least one command
+    2. The system executes the command(s) in a subshell
+    3. You see the result(s)
+    4. You write your next command(s)
+
+    Each response should include:
+
+    1. **Reasoning text** where you explain your analysis and plan
+    2. At least one tool call with your command
+
+    **CRITICAL REQUIREMENTS:**
+
+    - Your response SHOULD include reasoning text explaining what you're doing
+    - Your response MUST include AT LEAST ONE bash tool call
+    - Directory or environment variable changes are not persistent. Every action is executed in a new subshell.
+    - However, you can prefix any action with `MY_ENV_VAR=MY_VALUE cd /path/to/working/dir && ...` or write/load environment variables from files
+    - Submit your changes and finish your work by issuing the following command: `echo COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT`.
+      Do not combine it with any other command. <important>After this command, you cannot continue working on this task.</important>
+
+    Example of a CORRECT response:
+    <example_response>
+    I need to understand the structure of the repository first. Let me check what files are in the current directory to get a better understanding of the codebase.
+
+    [Makes bash tool call with {"command": "ls -la"} as arguments]
+    </example_response>
+
+    <system_information>
+    {{system}} {{release}} {{version}} {{machine}}
+    </system_information>
+
+    ## Useful command examples
+
+    ### Create a new file:
+
+    ```bash
+    cat <<'EOF' > newfile.py
+    import numpy as np
+    hello = "world"
+    print(hello)
+    EOF
+    ```
+
+    ### Edit files with sed:
+
+    {%- if system == "Darwin" -%}
+    <important>
+    You are on MacOS. For all the below examples, you need to use `sed -i ''` instead of `sed -i`.
+    </important>
+    {%- endif -%}
+
+    ```bash
+    # Replace all occurrences
+    sed -i 's/old_string/new_string/g' filename.py
+
+    # Replace only first occurrence
+    sed -i 's/old_string/new_string/' filename.py
+
+    # Replace first occurrence on line 1
+    sed -i '1s/old_string/new_string/' filename.py
+
+    # Replace all occurrences in lines 1-10
+    sed -i '1,10s/old_string/new_string/g' filename.py
+    ```
+
+    ### View file content:
+
+    ```bash
+    # View specific lines with numbers
+    nl -ba filename.py | sed -n '10,20p'
+    ```
+
+    ### Any other command you want to run
+
+    ```bash
+    anything
+    ```
+  step_limit: 0
+  cost_limit: 3.
+  mode: confirm
+environment:
+  env:
+    PAGER: cat
+    MANPAGER: cat
+    LESS: -R
+    PIP_PROGRESS_BAR: 'off'
+    TQDM_DISABLE: '1'
+model:
+  observation_template: |
+    {%- if output.output | length < 10000 -%}
+    {
+      "returncode": {{ output.returncode }},
+      "output": {{ output.output | tojson }}
+      {%- if output.exception_info %}, "exception_info": {{ output.exception_info | tojson }}{% endif %}
+    }
+    {%- else -%}
+    {
+      "returncode": {{ output.returncode }},
+      "output_head": {{ output.output[:5000] | tojson }},
+      "output_tail": {{ output.output[-5000:] | tojson }},
+      "elided_chars": {{ output.output | length - 10000 }},
+      "warning": "Output too long."
+      {%- if output.exception_info %}, "exception_info": {{ output.exception_info | tojson }}{% endif %}
+    }
+    {%- endif -%}
+  format_error_template: |
+    {% if finish_reason is defined and (finish_reason == "length" or (finish_reason == "tool_calls" and not has_tool_calls)) -%}
+    Your previous response reached the output token limit (finish_reason={{ finish_reason }}) before you produced a tool call, so it was cut off. Respond more concisely and finish with exactly one bash tool call. If you need to think more, do so briefly.
+    {%- else -%}
+    Tool call error:
+
+    <error>
+    {{error}}
+    </error>
+
+    Here is general guidance on how to submit correct toolcalls:
+
+    Every response needs to use the 'bash' tool at least once to execute commands.
+
+    Call the bash tool with your command as the argument:
+    - Tool: bash
+    - Arguments: {"command": "your_command_here"}
+
+    If you want to end the task, please issue the following command: `echo COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT`
+    without any other command.
+    {%- endif %}
+  model_kwargs:
+    drop_params: true


### PR DESCRIPTION
## Summary
- Adds `TodosAgent` (`agent_class: todos`) that injects a per-run `todo_path` (`.mini_todos/<session_id>.json`) so checklist files do not collide across sessions.
- Adds `mini_todos.yaml` with prompt-only guidance to create/update that JSON checklist; leaves `mini.yaml` / `default.yaml` unchanged.
- Ignores `.mini_todos/` in git.

## Test plan
- [ ] `mini -c mini_todos.yaml -y --exit-immediately -t "small task"`
- [ ] Confirm first user message contains a unique `.mini_todos/<id>.json` path
- [ ] Confirm the agent creates/updates that path (not a shared `.mini_todos.json`)
- [ ] Run twice in the same cwd and confirm two different session files under `.mini_todos/`
- [ ] Confirm stock `mini -c mini.yaml` behavior is unchanged


Made with [Cursor](https://cursor.com)