### PR TITLE
docs: clean up empty folder `minisweagent/run/extra`

### DIFF
--- a/src/minisweagent/run/README.md
+++ b/src/minisweagent/run/README.md
@@ -7,4 +7,4 @@
 
 ## Extras
 
-* `extra/swebench.py` - Benchmark the performance of the `default.py` agent.
+* `benchmarks/swebench.py` - Benchmark the performance of the `default.py` agent.


### PR DESCRIPTION
Looks like the folder was renamed `minisweagent/run/extra/` => `minisweagent/run/benchmarks/` in a [previous commit](https://github.com/SWE-agent/mini-swe-agent/commit/76363d1007736803801fdb365f1f6c682da9f0c0#diff-50fb5eda51bd1863962191fdd00bc2070a6e1acc92e84e486de891b0184f4f7a).

Just doing some extra cleanup now 😅 