### PR TITLE
fix(agents): reset per-run template vars across run() invocations

### DIFF
--- a/src/minisweagent/agents/default.py
+++ b/src/minisweagent/agents/default.py
@@ -43,6 +43,7 @@ class DefaultAgent:
         self.model = model
         self.env = env
         self.extra_template_vars = {}
+        self._run_template_vars = {}
         self.logger = logging.getLogger("agent")
         self.cost = 0.0
         self.n_calls = 0
@@ -60,6 +61,7 @@ class DefaultAgent:
                 "elapsed_seconds": int(time.time() - self._start_time),
             },
             self.extra_template_vars,
+            self._run_template_vars,
             kwargs,
         )
 
@@ -87,7 +89,7 @@ class DefaultAgent:
 
     def run(self, task: str = "", **kwargs) -> dict:
         """Run step() until agent is finished. Returns dictionary with exit_status, submission keys."""
-        self.extra_template_vars |= {"task": task, **kwargs}
+        self._run_template_vars = {"task": task, **kwargs}
         self.messages = []
         self.add_messages(
             self.model.format_message(role="system", content=self._render_template(self.config.system_template)),

--- a/tests/agents/test_default.py
+++ b/tests/agents/test_default.py
@@ -170,6 +170,43 @@ def test_step_limit_enforcement(model_factory):
     assert agent.n_calls == 1
 
 
+def test_run_resets_task_scoped_template_vars(model_factory):
+    """Reusing an agent gives each run independent template vars."""
+    factory, config = model_factory
+    agent = DefaultAgent(
+        model=factory(
+            [
+                ("First task", [{"command": "echo 'first'"}]),
+                ("Second task", [{"command": "echo 'second'"}]),
+            ]
+        ),
+        env=LocalEnvironment(),
+        **{**config, "step_limit": 1},
+    )
+
+    agent.run("First task", budget=5)
+    assert agent.get_template_vars()["budget"] == 5
+
+    agent.run("Second task")
+    assert agent.get_template_vars()["task"] == "Second task"
+    assert "budget" not in agent.get_template_vars()
+
+
+def test_externally_injected_template_vars_survive_run(model_factory):
+    """Template vars set on the agent before run() (e.g. benchmark instances) are preserved."""
+    factory, config = model_factory
+    agent = DefaultAgent(
+        model=factory([("Test", [{"command": "echo 'test'"}])]),
+        env=LocalEnvironment(),
+        **{**config, "step_limit": 1},
+    )
+    agent.extra_template_vars = {"instance": "repo__123"}
+
+    agent.run("Some task")
+
+    assert agent.get_template_vars()["instance"] == "repo__123"
+
+
 def test_cost_limit_enforcement(model_factory):
     """Test agent stops when cost limit is reached."""
     factory, config = model_factory


### PR DESCRIPTION
Closes the remaining gap in #909: PRs #910/#924 reset `cost`/`n_calls`/`n_consecutive_format_errors`/`_start_time`, but `run()` still accumulates `extra_template_vars |= {"task": task, **kwargs}` across invocations. Reusing an agent leaks the previous run's kwargs into the next run's templates (e.g. `run("task1", budget=5)` then `run("task2")` still exposes `budget=5` to `{{ budget }}`).

`extra_template_vars` is also the external injection channel -- `programbench.py` sets `{"instance": ...}` on the agent before `run()` -- so a blanket reset would break it. This PR separates concerns:

- `_run_template_vars`: per-run `task`/kwargs, replaced wholesale at the start of every `run()`
- `extra_template_vars`: untouched by `run()`, stays the persistent external injection channel

Tests:
- `test_run_resets_task_scoped_template_vars`: second run no longer sees the first run's kwargs
- `test_externally_injected_template_vars_survive_run`: pre-`run()` injection (benchmark-style) still renders