### PR TITLE
fix(agents): construct interactive prompt sessions lazily

### DIFF
--- a/src/minisweagent/agents/utils/prompt_user.py
+++ b/src/minisweagent/agents/utils/prompt_user.py
@@ -5,8 +5,31 @@ from prompt_toolkit.shortcuts import PromptSession
 from minisweagent import global_config_dir
 
 _history = FileHistory(global_config_dir / "interactive_history.txt")
-prompt_session = PromptSession(history=_history)
-_multiline_prompt_session = PromptSession(history=_history, multiline=True)
+
+
+class _LazyPromptSession:
+    """Defers PromptSession construction until the first prompt.
+
+    PromptSession probes the terminal when it is constructed; on Windows with a
+    non-console stdout (redirected output, or pytest's captured stdout) that
+    probe raises NoConsoleScreenBufferError. Building the sessions at import
+    time therefore broke importing the interactive agent on Windows, which the
+    Linux-only CI never saw. Constructing on first use defers the probe to the
+    only moment a real terminal is guaranteed to exist.
+    """
+
+    def __init__(self, **kwargs) -> None:
+        self._kwargs = kwargs
+        self._session: PromptSession | None = None
+
+    def prompt(self, *args, **kwargs):
+        if self._session is None:
+            self._session = PromptSession(**self._kwargs)
+        return self._session.prompt(*args, **kwargs)
+
+
+prompt_session = _LazyPromptSession(history=_history)
+_multiline_prompt_session = _LazyPromptSession(history=_history, multiline=True)
 
 
 def _multiline_prompt() -> str:

--- a/tests/agents/test_prompt_user.py
+++ b/tests/agents/test_prompt_user.py
@@ -1,0 +1,25 @@
+import importlib
+
+import prompt_toolkit.shortcuts
+
+
+def test_sessions_are_not_constructed_at_import(monkeypatch):
+    """Importing prompt_user must not construct a PromptSession.
+
+    PromptSession probes the terminal when it is constructed; on Windows with a
+    non-console stdout (redirected output, or pytest's captured stdout) that
+    probe raises NoConsoleScreenBufferError, so importing the interactive agent
+    crashed there while the Linux-only CI never saw it. The sessions are wrapped
+    so construction is deferred to the first prompt, when a real terminal exists.
+    """
+    import minisweagent.agents.utils.prompt_user as prompt_user
+
+    def _fail(*args, **kwargs):
+        raise RuntimeError("PromptSession must not be constructed at import time")
+
+    monkeypatch.setattr(prompt_toolkit.shortcuts, "PromptSession", _fail)
+    try:
+        importlib.reload(prompt_user)  # must not raise while PromptSession is unusable
+    finally:
+        monkeypatch.undo()
+        importlib.reload(prompt_user)  # restore the real binding for other tests


### PR DESCRIPTION
## What breaks

On Windows, importing `minisweagent.agents.interactive` (or `minisweagent.run.mini`, which imports `_multiline_prompt`) crashes with `prompt_toolkit.output.win32.NoConsoleScreenBufferError` whenever stdout is not a live console screen buffer — output redirected to a file, piped, or captured by a test runner:

```
$ python -c "import minisweagent.agents.interactive" > out.txt
...
prompt_toolkit/output/win32.py: raise NoConsoleScreenBufferError
```

On this repo's test suite it shows up as a collection error: `pytest` captures stdout, so on Windows six modules fail to even collect (`test_init`, `test_interactive`, `test_cli_integration`, `test_local`, and the two `extra` modules).

## Mechanism

`src/minisweagent/agents/utils/prompt_user.py` constructs two `PromptSession` objects at module import time:

```python
prompt_session = PromptSession(history=_history)
_multiline_prompt_session = PromptSession(history=_history, multiline=True)
```

`PromptSession.__init__` eagerly builds an `Application`, which calls `create_output()`. On Windows a non-console stdout resolves to `Win32Output`, whose `get_win32_screen_buffer_info()` raises `NoConsoleScreenBufferError`. On Linux/macOS the same non-tty stdout resolves to `Vt100_Output`, which performs no such probe — which is why the Linux-only CI never sees this.

## The fix

Wrap each session in a tiny lazy holder that constructs the real `PromptSession` on the first `prompt()` call, when an interactive terminal actually exists. The module-level names `prompt_session` and `_multiline_prompt_session` are kept, and only `.prompt` is used at the call sites, so nothing else changes — including the tests that `patch("...prompt_user.prompt_session.prompt", ...)`. One file changed (plus a regression test).

## Fail-before / pass-after (native Windows 11, Python 3.13)

- `python -c "import minisweagent.agents.interactive"` with stdout redirected: raises before, prints `imported OK` after.
- The six modules: **error during collection before**; after the fix, e.g. `tests/agents/test_init.py` goes from a collection error to **9 passed**, and `test_cli_integration.py` + `test_local.py` collect 141 tests.
- Added `tests/agents/test_prompt_user.py`: it patches `prompt_toolkit.shortcuts.PromptSession` to raise, reloads the module, and asserts the import does not construct a session. **Fails before this change, passes after** — verified by stashing the fix and re-running. This guard fails-before on Linux too (via the patched-reload path), so it protects the maintainer's CI, not just Windows.

## What is deliberately unchanged, and an honest limit

This is scoped to the import-time construction only. The repo's suite has substantial **pre-existing** failures on native Windows that are unrelated to this change — the interactive/CLI tests run agents end-to-end against scripted test-models and shell out to the `mini` console script. To confirm they aren't mine, `tests/agents/test_default.py` (which collects on `main` too) fails an **identical 28 tests** with and without this change (verified by stashing the fix). This PR does not attempt to make those pass.

Honest limit: on native Windows, `main` cannot import the module at all, so I can't produce a Windows baseline for the modules that only begin collecting after this fix — I verified those by the import repro above and by the modules that collect on both revisions. On Linux CI, this change only defers construction, so behaviour there is unchanged apart from the one added test.
