### PR TITLE
fix(models): guard missing total_tokens in PortkeyModel cost tracking

### DIFF
--- a/src/minisweagent/models/portkey_model.py
+++ b/src/minisweagent/models/portkey_model.py
@@ -183,6 +183,16 @@ class PortkeyModel:
                 f"Completion tokens are None for model {self.config.model_name}. Setting to 0. Full response: {response_for_cost_calc.model_dump()}"
             )
             completion_tokens = 0
+        if total_tokens is None or total_tokens == 0:
+            # Some providers omit total_tokens entirely, which litellm
+            # surfaces as None (TypeError below) or 0 (the consistency check
+            # would rewrite prompt_tokens to a negative number).  Inferring
+            # the total from the parts keeps the real usage instead of
+            # silently zeroing it (see #781/#779).
+            logger.warning(
+                f"Total tokens are None or 0 for model {self.config.model_name}. Inferring total from prompt + completion tokens. Full response: {response_for_cost_calc.model_dump()}"
+            )
+            total_tokens = prompt_tokens + completion_tokens
         if total_tokens - prompt_tokens - completion_tokens != 0:
             # This is most likely related to how portkey treats cached tokens: It doesn't count them towards the prompt tokens (?)
             logger.warning(

--- a/tests/models/test_portkey_model.py
+++ b/tests/models/test_portkey_model.py
@@ -191,3 +191,40 @@ def test_portkey_model_cost_validation_error():
 
                 assert "Error calculating cost" in str(exc_info.value)
                 assert "MSWEA_COST_TRACKING='ignore_errors'" in str(exc_info.value)
+
+
+def test_portkey_model_calculate_cost_total_tokens_none():
+    """Regression guard: `usage.total_tokens=None` must not crash cost tracking.
+
+    Portkey sometimes omits ``total_tokens`` for a provider response, and
+    ``_calculate_cost`` would run ``None - prompt - completion`` and raise
+    ``TypeError``.  Unlike setting the value to 0 (rejected in #781/#779
+    because it would make cost limits unreachable), inferring the total from
+    prompt + completion tokens keeps the real usage while avoiding the crash.
+    """
+    from types import SimpleNamespace
+
+    from litellm import ModelResponse, Usage
+
+    response = ModelResponse(
+        model="gpt-4o",
+        usage=Usage(prompt_tokens=10, completion_tokens=5, total_tokens=None),
+    )
+    model = PortkeyModel.__new__(PortkeyModel)
+    model.config = SimpleNamespace(
+        litellm_model_name_override="",
+        cost_tracking="default",
+        model_name="gpt-4o",
+    )
+
+    with patch("minisweagent.models.portkey_model.litellm.cost_calculator.completion_cost") as mock_cost:
+        mock_cost.return_value = 0.01
+
+        result = model._calculate_cost(response)
+
+        assert result == {"cost": 0.01}
+        # The inferred total (10 + 5) matches the parts, so the
+        # "total != prompt + completion" rewrite branch must not trigger.
+        passed = mock_cost.call_args.args[0]
+        assert passed.usage.prompt_tokens == 10
+        assert passed.usage.completion_tokens == 5


### PR DESCRIPTION
Fixes #935

## Root cause

`PortkeyModel._calculate_cost()` guards `prompt_tokens` and `completion_tokens` against `None` but not `total_tokens`. Some providers omit `usage.total_tokens`; litellm surfaces it as `None` (→ `TypeError` in `total_tokens - prompt - completion`, crashing the run since `_calculate_cost` runs outside the retry loop) or as `0` (→ the consistency check rewrites `prompt_tokens` to a **negative** number, e.g. -5 for prompt=10/completion=5).

## Fix

When `total_tokens` is `None` or `0`, infer it from `prompt_tokens + completion_tokens` with a warning — instead of zeroing it (zeroing was rejected in #781/#779 because cost limits then never trigger). The consistency check then passes and cost is computed from the real usage.

## Testing

- Added regression test `test_portkey_model_calculate_cost_total_tokens_none` (fails before: prompt_tokens rewritten to -5; passes after)
- `pytest tests/models/`: 140 passed
- ruff: clean