### PR TITLE
fix(deps): pin litellm for reproducible installs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "requests",
     "jinja2",
     "pydantic >= 2.0",  # v2 required for safe mutable default arguments
-    "litellm >= 1.75.5, != 1.82.7, != 1.82.8", # Security: Skip compromised 1.82.7/8; requires 1.75.5+ for GPT-5
+    "litellm == 1.96.0",  # Pin tested LiteLLM release to avoid install-time drift; includes the Gemini signature fix
     "tenacity",
     "rich",
     "python-dotenv",

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,8 +1,11 @@
 """Tests for minisweagent.__init__."""
 
+import importlib.metadata
 import os
 import subprocess
 import sys
+
+from packaging.requirements import Requirement
 
 
 def test_startup_banner_survives_non_utf8_stdout(tmp_path):
@@ -15,3 +18,9 @@ def test_startup_banner_survives_non_utf8_stdout(tmp_path):
     }
     result = subprocess.run([sys.executable, "-c", "import minisweagent"], capture_output=True, text=True, env=env)
     assert result.returncode == 0, result.stderr
+
+
+def test_litellm_dependency_is_pinned():
+    requirements = [Requirement(req) for req in importlib.metadata.requires("mini-swe-agent") or []]
+    litellm = next(req for req in requirements if req.name == "litellm")
+    assert str(litellm.specifier) == "==1.96.0"


### PR DESCRIPTION
Fixes #941

Fresh installs currently resolve whatever LiteLLM release is newest that day because `pyproject.toml` leaves the dependency open-ended. In the current index that drifts to `litellm 1.97.0`, so two installs a week apart can land on different runtime behavior even though the mini-swe-agent code is unchanged.

This change pins `litellm` to the tested `1.96.0` release instead of a floating lower bound, and adds a regression test that asserts the published package metadata keeps that exact pin. I verified the install-time effect in isolated virtual environments: before this patch a fresh editable install resolved `litellm 1.97.0`, after the patch it resolves `1.96.0`.

Validation:
- `uv pip install --python $(command -v python) -e '.[full]'`
- `python -m pytest tests/test_init.py -q`
- `python -m pytest tests/models/test_litellm_model.py -q`
- `python -m pytest -n auto -q` (`584 passed, 36 skipped`)
- `pre-commit run --files pyproject.toml tests/test_init.py`
