### PR TITLE
fix(config): Fall back to notepad instead of nano on Windows in config edit

### DIFF
--- a/src/minisweagent/run/utilities/config.py
+++ b/src/minisweagent/run/utilities/config.py
@@ -8,6 +8,7 @@ It is located at [bold green]{global_config_file}[/bold green].
 """
 
 import os
+import platform
 import subprocess
 
 from dotenv import load_dotenv, set_key, unset_key
@@ -122,7 +123,7 @@ def unset(key: str | None = Argument(None, help="The key to unset")):
 @app.command()
 def edit():
     """Edit the global config file."""
-    editor = os.getenv("EDITOR", "nano")
+    editor = os.getenv("EDITOR", "notepad" if platform.system() == "Windows" else "nano")
     subprocess.run([editor, global_config_file])
     _reload_config()
 

--- a/tests/run/test_extra_config.py
+++ b/tests/run/test_extra_config.py
@@ -376,18 +376,34 @@ class TestConfigEdit:
     """Test the edit function."""
 
     def test_edit_with_default_editor(self, tmp_path):
-        """Test edit function with default editor (nano)."""
+        """Test edit function with default editor (nano) on non-Windows platforms."""
         config_file = tmp_path / ".env"
         config_file.write_text("MSWEA_MODEL_NAME=test")
 
         with (
             patch("minisweagent.run.utilities.config.global_config_file", config_file),
             patch("subprocess.run") as mock_run,
+            patch("platform.system", return_value="Linux"),
             patch.dict(os.environ, {}, clear=True),  # Clear EDITOR env var
         ):
             edit()
 
             mock_run.assert_called_once_with(["nano", config_file])
+
+    def test_edit_with_default_editor_on_windows(self, tmp_path):
+        """Test edit function falls back to notepad on Windows when EDITOR is unset."""
+        config_file = tmp_path / ".env"
+        config_file.write_text("MSWEA_MODEL_NAME=test")
+
+        with (
+            patch("minisweagent.run.utilities.config.global_config_file", config_file),
+            patch("subprocess.run") as mock_run,
+            patch("platform.system", return_value="Windows"),
+            patch.dict(os.environ, {}, clear=True),  # Clear EDITOR env var
+        ):
+            edit()
+
+            mock_run.assert_called_once_with(["notepad", config_file])
 
     def test_edit_with_custom_editor(self, tmp_path):
         """Test edit function with custom editor."""


### PR DESCRIPTION
Fixes #931

nano is typically unavailable on Windows, so `mini-extra config edit` raised `FileNotFoundError` when `EDITOR` was unset. This falls back to `notepad` on Windows instead, and keeps `nano` as the default elsewhere. An explicitly set `EDITOR` is still respected on any platform.

Added a regression test (`test_edit_with_default_editor_on_windows`) and updated the existing default-editor test to pin the platform explicitly.