### PR TITLE
fix(config): use a Windows-safe default editor

### DIFF
--- a/src/minisweagent/run/utilities/config.py
+++ b/src/minisweagent/run/utilities/config.py
@@ -9,6 +9,7 @@ It is located at [bold green]{global_config_file}[/bold green].
 
 import os
 import subprocess
+import sys
 
 from dotenv import load_dotenv, set_key, unset_key
 from rich.console import Console
@@ -122,7 +123,7 @@ def unset(key: str | None = Argument(None, help="The key to unset")):
 @app.command()
 def edit():
     """Edit the global config file."""
-    editor = os.getenv("EDITOR", "nano")
+    editor = os.getenv("EDITOR") or ("notepad.exe" if sys.platform == "win32" else "nano")
     subprocess.run([editor, global_config_file])
     _reload_config()
 

--- a/tests/run/test_extra_config.py
+++ b/tests/run/test_extra_config.py
@@ -382,12 +382,28 @@ class TestConfigEdit:
 
         with (
             patch("minisweagent.run.utilities.config.global_config_file", config_file),
+            patch("minisweagent.run.utilities.config.sys.platform", "linux"),
             patch("subprocess.run") as mock_run,
             patch.dict(os.environ, {}, clear=True),  # Clear EDITOR env var
         ):
             edit()
 
             mock_run.assert_called_once_with(["nano", config_file])
+
+    def test_edit_with_default_editor_on_windows(self, tmp_path):
+        """Test edit function with the Windows default editor."""
+        config_file = tmp_path / ".env"
+        config_file.write_text("MSWEA_MODEL_NAME=test")
+
+        with (
+            patch("minisweagent.run.utilities.config.global_config_file", config_file),
+            patch("minisweagent.run.utilities.config.sys.platform", "win32"),
+            patch("subprocess.run") as mock_run,
+            patch.dict(os.environ, {}, clear=True),
+        ):
+            edit()
+
+            mock_run.assert_called_once_with(["notepad.exe", config_file])
 
     def test_edit_with_custom_editor(self, tmp_path):
         """Test edit function with custom editor."""


### PR DESCRIPTION
## Summary

- use `notepad.exe` as the default config editor on Windows
- retain `nano` as the default on Unix-like systems
- continue honoring an explicitly configured `EDITOR`
- add regression coverage for the Windows default editor

## Testing

- `pytest -q tests/run/test_extra_config.py`
- `ruff check src/minisweagent/run/utilities/config.py tests/run/test_extra_config.py`
- `git diff --check`

Fixes #931
