### PR TITLE
fix(env): separate execution and reported timeout durations

### DIFF
--- a/src/minisweagent/config/mini.yaml
+++ b/src/minisweagent/config/mini.yaml
@@ -102,6 +102,8 @@ agent:
   cost_limit: 3.
   mode: confirm
 environment:
+  timeout: 30
+  timeout_duration: 5
   env:
     PAGER: cat
     MANPAGER: cat

--- a/src/minisweagent/environments/local.py
+++ b/src/minisweagent/environments/local.py
@@ -14,6 +14,9 @@ class LocalEnvironmentConfig(BaseModel):
     cwd: str = ""
     env: dict[str, str] = {}
     timeout: int = 30
+    """Timeout for executing commands."""
+    timeout_duration: int | None = None
+    """Optional timeout duration reported to the model after a command times out."""
 
 
 class LocalEnvironment:
@@ -25,19 +28,23 @@ class LocalEnvironment:
         """Execute a command in the local environment and return the result as a dict."""
         command = action.get("command", "")
         cwd = cwd or self.config.cwd or os.getcwd()
+        actual_timeout = timeout or self.config.timeout
         try:
-            result = _run(command, cwd, os.environ | self.config.env, timeout or self.config.timeout)
+            result = _run(command, cwd, os.environ | self.config.env, actual_timeout)
             output = {"output": result.stdout, "returncode": result.returncode, "exception_info": ""}
         except Exception as e:
             raw_output = getattr(e, "output", None)
             raw_output = (
                 raw_output.decode("utf-8", errors="replace") if isinstance(raw_output, bytes) else (raw_output or "")
             )
+            if isinstance(e, subprocess.TimeoutExpired):
+                e.timeout = self.config.timeout_duration or e.timeout
+            exception = str(e)
             output = {
                 "output": raw_output,
                 "returncode": -1,
-                "exception_info": f"An error occurred while executing the command: {e}",
-                "extra": {"exception_type": type(e).__name__, "exception": str(e)},
+                "exception_info": f"An error occurred while executing the command: {exception}",
+                "extra": {"exception_type": type(e).__name__, "exception": exception},
             }
         self._check_finished(output)
         return output

--- a/tests/environments/test_local.py
+++ b/tests/environments/test_local.py
@@ -19,6 +19,7 @@ def test_local_environment_config_defaults():
     assert config.cwd == ""
     assert config.env == {}
     assert config.timeout == 30
+    assert config.timeout_duration is None
 
 
 def test_local_environment_basic_execution():
@@ -132,6 +133,17 @@ def test_local_environment_timeout():
     assert result["returncode"] == -1
     assert "timed out" in result["exception_info"]
     assert result["extra"]["exception_type"] == "TimeoutExpired"
+
+
+def test_local_environment_timeout_reports_model_facing_duration():
+    """Test timeout output reports its model-facing duration, not the execution limit."""
+    env = LocalEnvironment(timeout=1, timeout_duration=5)
+
+    result = env.execute({"command": "sleep 2"})
+
+    assert result["returncode"] == -1
+    assert "timed out after 5 seconds" in result["exception_info"]
+    assert result["extra"]["exception"] == "Command 'sleep 2' timed out after 5 seconds"
 
 
 @pytest.mark.skipif(os.name == "nt", reason="process groups are POSIX-specific")


### PR DESCRIPTION
Fixes #950\n\nThe local environment still enforces the configured 30-second execution timeout, while the default mini config tells the model that timed-out commands took 5 seconds. This avoids encouraging  after a timeout, without reducing the actual command budget.\n\nAdds focused coverage for the model-facing timeout message.