### PR TITLE
fix(models): use provider-reported response cost when available

### DIFF
--- a/src/minisweagent/models/litellm_model.py
+++ b/src/minisweagent/models/litellm_model.py
@@ -107,7 +107,9 @@ class LitellmModel:
 
     def _calculate_cost(self, response) -> dict[str, float]:
         try:
-            cost = litellm.cost_calculator.completion_cost(response, model=self.config.model_name)
+            cost = (getattr(response, "_hidden_params", None) or {}).get("response_cost")
+            if cost is None:
+                cost = litellm.cost_calculator.completion_cost(response, model=self.config.model_name)
             if cost <= 0.0:
                 raise ValueError(f"Cost must be > 0.0, got {cost}")
         except Exception as e:

--- a/tests/models/test_anthropic_model_integration.py
+++ b/tests/models/test_anthropic_model_integration.py
@@ -11,6 +11,7 @@ from minisweagent.models import get_model
 def _mock_litellm_completion(response_content="```mswea_bash_command\necho test\n```"):
     """Helper to create consistent litellm mocks. Response must include bash block for parse_action."""
     mock_response = MagicMock()
+    mock_response._hidden_params = {}
     mock_response.choices = [MagicMock()]
     mock_response.choices[0].message.content = response_content
     mock_response.model_dump.return_value = {"mock": "response"}

--- a/tests/models/test_litellm_model.py
+++ b/tests/models/test_litellm_model.py
@@ -12,8 +12,9 @@ class TestLitellmModelConfig:
         assert LitellmModelConfig(model_name="test").format_error_template == "{{ error }}"
 
 
-def _mock_litellm_response(tool_calls):
+def _mock_litellm_response(tool_calls, hidden_params: dict | None = None):
     mock_response = MagicMock()
+    mock_response._hidden_params = hidden_params or {}
     mock_response.choices = [MagicMock()]
     mock_response.choices[0].message.tool_calls = tool_calls
     mock_response.choices[0].message.model_dump.return_value = {"role": "assistant", "content": None}
@@ -79,6 +80,35 @@ class TestLitellmModel:
         with pytest.raises(FormatError) as exc:
             model.query([{"role": "user", "content": "test"}])
         assert exc.value.messages[0]["content"] == "cut off"
+
+    @patch("minisweagent.models.litellm_model.litellm.completion")
+    @patch("minisweagent.models.litellm_model.litellm.cost_calculator.completion_cost")
+    def test_cost_prefers_provider_reported_response_cost(self, mock_cost, mock_completion):
+        """A provider-reported cost in _hidden_params (e.g. from OpenRouter via litellm) is used
+        as-is, even for models missing from litellm's price map, without calling completion_cost."""
+        tool_call = MagicMock()
+        tool_call.function.name = "bash"
+        tool_call.function.arguments = '{"command": "echo test"}'
+        tool_call.id = "call_1"
+        mock_completion.return_value = _mock_litellm_response([tool_call], hidden_params={"response_cost": 0.4038})
+
+        model = LitellmModel(model_name="openrouter/some/unmapped-model")
+        assert model.query([{"role": "user", "content": "test"}])["extra"]["cost"] == 0.4038
+        mock_cost.assert_not_called()
+
+    @patch("minisweagent.models.litellm_model.litellm.completion")
+    @patch("minisweagent.models.litellm_model.litellm.cost_calculator.completion_cost")
+    def test_cost_falls_back_to_completion_cost(self, mock_cost, mock_completion):
+        tool_call = MagicMock()
+        tool_call.function.name = "bash"
+        tool_call.function.arguments = '{"command": "echo test"}'
+        tool_call.id = "call_1"
+        mock_completion.return_value = _mock_litellm_response([tool_call])
+        mock_cost.return_value = 0.002
+
+        model = LitellmModel(model_name="gpt-4")
+        assert model.query([{"role": "user", "content": "test"}])["extra"]["cost"] == 0.002
+        mock_cost.assert_called_once()
 
     def test_format_observation_messages(self):
         model = LitellmModel(model_name="gpt-4", observation_template="{{ output.output }}")

--- a/tests/models/test_litellm_textbased_model.py
+++ b/tests/models/test_litellm_textbased_model.py
@@ -93,6 +93,7 @@ def test_litellm_model_cost_tracking_ignore_errors():
             "role": "assistant",
             "content": "```mswea_bash_command\necho test\n```",
         }
+        mock_response._hidden_params = {}
         mock_response.choices = [Mock(message=mock_message)]
         mock_response.model_dump.return_value = {"test": "response"}
         mock_completion.return_value = mock_response
@@ -112,6 +113,7 @@ def test_litellm_model_cost_validation_zero_cost():
 
     with patch("litellm.completion") as mock_completion:
         mock_response = Mock()
+        mock_response._hidden_params = {}
         mock_response.choices = [Mock(message=Mock(content="Test response"))]
         mock_response.model_dump.return_value = {"test": "response"}
         mock_completion.return_value = mock_response


### PR DESCRIPTION
## Problem

`LitellmModel._calculate_cost` computes cost with `litellm.cost_calculator.completion_cost(...)`, which only consults litellm's bundled static price map. But for many providers litellm already has the authoritative, provider-billed cost attached to the response object:

- litellm's OpenRouter transform always injects `usage: {include: true}` and copies the returned `usage.cost` into the response's hidden params (`litellm/llms/openrouter/chat/transformation.py`).
- litellm's own `response_cost_calculator` prefers that provider-supplied number over any price-map lookup and stamps it onto `_hidden_params["response_cost"]`.
- `completion_cost`, however, never consults `_hidden_params` — it recomputes from the price map.

So for any model id absent from the price map, `completion_cost` raises, the error is swallowed under `MSWEA_COST_TRACKING=ignore_errors`, and `instance_cost` is silently recorded as `0.0` — even though the exact billed amount is sitting on the response object (and is persisted in every saved trajectory at `extra.response.usage.cost`).

## Evidence

From three production runs on OpenRouter-hosted models absent from litellm's price map:

| model | true cost (summed from `usage.cost` in the trajectory) | recorded `instance_cost` |
|---|---|---|
| `openrouter/z-ai/glm-5.3` | $0.4038 over 30 calls | 0.0 |
| `openrouter/moonshotai/kimi-k3` | $0.5338 over 19 calls | 0.0 |
| `openrouter/x-ai/grok-4.6` | $1.8823 over 33 calls | 1.346158 (via a hand-written registry entry) |

The grok row is worth a look: even a hand-maintained price entry undercounted real billed spend by 28% (caching/discount dynamics the static table can't see). That's the argument for preferring the provider's own number whenever it exists, rather than maintaining overrides.

## Fix

In `_calculate_cost`, use `_hidden_params["response_cost"]` when litellm has populated it, and fall back to the existing `completion_cost` call when it hasn't:

```python
cost = (getattr(response, "_hidden_params", None) or {}).get("response_cost")
if cost is None:
    cost = litellm.cost_calculator.completion_cost(response, model=self.config.model_name)
```

Everything around it is unchanged: the `cost <= 0.0` check, the `cost_tracking: ignore_errors` handling, the returned dict shape. `LitellmResponseModel` and `LitellmTextbasedModel` inherit this method and get the fix for free.

## Tests

Added to `tests/models/test_litellm_model.py`:

- `test_cost_prefers_provider_reported_response_cost` — `_hidden_params["response_cost"]` present → that value is used and `completion_cost` is not called.
- `test_cost_falls_back_to_completion_cost` — hidden params empty → `completion_cost` is used, called once.

Existing mocked responses in the test suite gained `_hidden_params = {}`, matching real litellm responses (`litellm.ModelResponse()._hidden_params` is always a dict). `pytest -n auto`: 532 passed, 76 skipped (the 2 pre-existing collection errors are the optional `contree_sdk`/`swerex` extras, unrelated). `ruff check` / `ruff format` clean.

## Scope and prior art

- `OpenRouterModel` (the native client) already reads `usage.cost` directly — untouched. The Portkey models build responses from Portkey's HTTP API outside litellm's client, so `_hidden_params` is never populated there — also untouched.
- #591 / #593 / #596 dealt with *allowing* zero cost for free/local models; this PR is about paid models being recorded as free.
- #752 added a model-name override for the cost calc and was reverted the same day. This PR is the opposite of another override surface: it uses the number litellm itself designates as authoritative, and only falls back to recomputation when the provider didn't report one.
