### PR TITLE
fix(agents): don't substitute emoji shortcodes in printed message content

### DIFF
--- a/src/minisweagent/agents/interactive.py
+++ b/src/minisweagent/agents/interactive.py
@@ -52,7 +52,7 @@ class InteractiveAgent(DefaultAgent):
                 )
             else:
                 console.print(f"\n[bold green]{role.capitalize()}[/bold green]:\n", end="", highlight=False)
-            console.print(content, highlight=False, markup=False)
+            console.print(content, highlight=False, markup=False, emoji=False)
         return super().add_messages(*messages)
 
     def query(self) -> dict:

--- a/tests/agents/test_interactive.py
+++ b/tests/agents/test_interactive.py
@@ -1254,3 +1254,22 @@ def test_submission_enter_quits(model_factory):
     assert info["exit_status"] == "Submitted"
     assert info["submission"] == "completed\n"
     assert agent.n_calls == 1
+
+
+def test_emoji_shortcodes_in_content_are_not_substituted(model_factory, capsys):
+    """Rich substitutes `:shortcode:` with emoji independently of markup, mangling messages."""
+    factory, config = model_factory
+    with mock_prompts([""]):  # At submission prompt: Enter to quit
+        agent = InteractiveAgent(
+            model=factory(
+                [
+                    ("Checking the dependency", [{"command": "echo 'androidx.test:runner:1.6.1'"}]),
+                    ("androidx.test:runner:1.6.1", [{"command": "echo 'COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT'"}]),
+                ]
+            ),
+            env=LocalEnvironment(),
+            **{**config, "mode": "yolo"},
+        )
+        agent.run("Solve the issue")
+    # Once for the command output, once for the assistant message
+    assert capsys.readouterr().out.count("androidx.test:runner:1.6.1") >= 2


### PR DESCRIPTION
Fixes #947

### Problem

Message content containing `:runner:` renders as 🏃 in the terminal, so `androidx.test:runner:1.6.1` is displayed as `androidx.test🏃1.6.1`. The reporter's own hex dump in the issue shows the source bytes are plain ASCII (`3a 72 75 6e 6e 65 72 3a` = `:runner:`), so the text is intact right up until the display layer.

### Cause

`InteractiveAgent.add_messages` prints message content with `markup=False`, but Rich's emoji substitution is a separate switch from markup. `rich/console.py::render_str` runs `_emoji_replace` in the non-markup branch as well:

```python
emoji_enabled = emoji or (emoji is None and self._emoji)  # defaults to True
markup_enabled = markup or (markup is None and self._markup)
if markup_enabled:
    rich_text = render_markup(text, style=style, emoji=emoji_enabled, ...)
else:
    rich_text = Text(_emoji_replace(text, ...) if emoji_enabled else text, ...)
```

and `rich/_emoji_codes.py` maps `"runner": "🏃"`. Reproduced on rich 15.0.0:

```pycon
>>> Console(highlight=False).print("androidx.test:runner:1.6.1", highlight=False, markup=False)
androidx.test🏃1.6.1
```

`:runner:` is not a special case. `:cd:`, `:snake:`, `:rocket:`, `:warning:` and `:100:` are all live shortcodes that collide with ordinary Gradle/Maven coordinates, log lines and diffs.

### Fix

Pass `emoji=False` next to the existing `markup=False` on the single print that handles LM and tool output.

I deliberately left the module level `Console(highlight=False)` alone, so the agent's own prompts and status strings are untouched and the call site stays self-documenting. `grep` over `src/` finds no emoji shortcodes in the project's own strings, so no intended rendering changes.

The trajectory inspector is already safe: it builds `Text.from_ansi(...)`, a literal `Text` that never passes through `render_str`.

### Test

`test_emoji_shortcodes_in_content_are_not_substituted` runs an agent with the shortcode in both an assistant message and a command output, the two places the screenshots show it mangled, and asserts both print verbatim. It covers all three model formats through the existing `model_factory` fixture and fails on `main` with `assert 0 >= 2`.

`pytest tests/agents tests/run tests/models tests/config tests/utils`: 505 passed, 15 skipped.