### PR TITLE
fix(models): reject non-string bash tool commands

### DIFF
--- a/src/minisweagent/models/utils/actions_toolcall.py
+++ b/src/minisweagent/models/utils/actions_toolcall.py
@@ -62,6 +62,8 @@ def parse_toolcall_actions(
             error_msg += f"Unknown tool '{tool_call.function.name}'."
         if not isinstance(args, dict) or "command" not in args:
             error_msg += "Missing 'command' argument in bash tool call."
+        elif not isinstance(args["command"], str):
+            error_msg += "'command' argument must be a string."
         if error_msg:
             raise FormatError(
                 {

--- a/src/minisweagent/models/utils/actions_toolcall_response.py
+++ b/src/minisweagent/models/utils/actions_toolcall_response.py
@@ -95,6 +95,8 @@ def parse_toolcall_actions_response(
             error_msg += f"Unknown tool '{tool_call.get('name')}'."
         if not isinstance(args, dict) or "command" not in args:
             error_msg += "Missing 'command' argument in bash tool call."
+        elif not isinstance(args["command"], str):
+            error_msg += "'command' argument must be a string."
         if error_msg:
             error_text = Template(format_error_template, undefined=StrictUndefined).render(
                 error=error_msg.strip(), actions=[], has_tool_calls=True, **template_kwargs

--- a/tests/models/test_actions_toolcall.py
+++ b/tests/models/test_actions_toolcall.py
@@ -1,6 +1,8 @@
+import json
 from unittest.mock import MagicMock
 
 import pytest
+from litellm.types.utils import ChatCompletionMessageToolCall
 
 from minisweagent.exceptions import FormatError
 from minisweagent.models.utils.actions_toolcall import (
@@ -8,6 +10,42 @@ from minisweagent.models.utils.actions_toolcall import (
     format_toolcall_observation_messages,
     parse_toolcall_actions,
 )
+from minisweagent.models.utils.actions_toolcall_response import parse_toolcall_actions_response
+
+
+@pytest.mark.parametrize(
+    ("command", "response_api"),
+    [
+        (command, response_api)
+        for command in [None, 42, True, ["echo hello"], {"text": "echo hello"}]
+        for response_api in [False, True]
+    ],
+)
+def test_non_string_command_raises_format_error(command: object, response_api: bool):
+    calls = [
+        {"type": "function_call", "call_id": "call_valid", "name": "bash", "arguments": '{"command": "echo hello"}'},
+        {
+            "type": "function_call",
+            "call_id": "call_invalid",
+            "name": "bash",
+            "arguments": json.dumps({"command": command}),
+        },
+    ]
+    if not response_api:
+        calls = [
+            ChatCompletionMessageToolCall(
+                id=call["call_id"], type="function", function={"name": call["name"], "arguments": call["arguments"]}
+            )
+            for call in calls
+        ]
+    with pytest.raises(FormatError) as exc_info:
+        (parse_toolcall_actions_response if response_api else parse_toolcall_actions)(
+            calls, format_error_template="{{ error }}"
+        )
+    message = exc_info.value.messages[0]
+    content = message["content"][0]["text"] if response_api else message["content"]
+    assert "'command' argument must be a string" in content
+    assert message["extra"]["interrupt_type"] == "FormatError"
 
 
 class TestParseToolcallActions:


### PR DESCRIPTION
Both bash tool schemas declare `command` as a string, but the chat-completions and Responses API parsers currently only check that the key exists. A response such as `{"command": null}` or `{"command": ["echo hello"]}` is therefore accepted as an action and forwarded to the environment instead of producing a format error for the model to correct.

Validate the command type in both parsers using the existing `FormatError` path. The regression test covers null, number, boolean, array, and object values in both API formats, including an invalid call following a valid one. It uses a real LiteLLM tool-call object and plain Responses API data, with no new mocks or live API calls.

Validation:
- Before the fix: all 10 new cases fail because no `FormatError` is raised; the 13 existing parser tests pass.
- After the fix: `pytest tests/models/test_actions_toolcall.py tests/models/test_truncation_finish_reason.py tests/models/test_portkey_response_model.py -q` — 46 passed.
- All applicable pre-commit hooks pass (including Ruff, formatting, typos, and secret detection).
- Source distribution and wheel build successfully with uv build.
