### PR TITLE
fix(benchmarks): preserve live observations when saving ProgramBench trajectories

### DIFF
--- a/src/minisweagent/run/benchmarks/programbench.py
+++ b/src/minisweagent/run/benchmarks/programbench.py
@@ -35,6 +35,7 @@ class ProgramBenchAgent(ProgressTrackingAgent):
 
     def serialize(self, *extra_dicts) -> dict:
         data = super().serialize(*extra_dicts)
+        data["messages"] = copy.deepcopy(data["messages"])
         for msg in data.get("messages", []):
             extra = msg.get("extra", {})
             extra.pop("raw_output", None)

--- a/tests/run/test_programbench.py
+++ b/tests/run/test_programbench.py
@@ -8,6 +8,7 @@ package to be installed so we verify API compatibility with what programbench
 actually ships — they're skipped via ``pytest.importorskip`` when not available.
 """
 
+import copy
 import json
 import tarfile
 from unittest.mock import MagicMock, patch
@@ -18,12 +19,44 @@ from pydantic import BaseModel
 
 from minisweagent import package_dir
 from minisweagent.environments.docker import DockerEnvironment
+from minisweagent.environments.local import LocalEnvironment
 from minisweagent.exceptions import Submitted
-from minisweagent.run.benchmarks.programbench import copy_submission, main
+from minisweagent.models.test_models import DeterministicModel
+from minisweagent.run.benchmarks.programbench import ProgramBenchAgent, copy_submission, main
+from minisweagent.run.benchmarks.utils.batch_progress import RunBatchProgressManager
 
 # Lightweight image used for the real-docker tests. Already cached on machines
 # that run mini-swe-agent's docker test suite (see tests/environments/test_docker.py).
 _TEST_IMAGE = "python:3.11"
+
+
+@pytest.mark.parametrize(
+    ("extra", "saved_extra"),
+    [
+        ({"raw_output": "command output", "returncode": 0}, {"returncode": 0}),
+        (
+            {"observations": [{"raw_output": "command output", "returncode": 0}]},
+            {"observations": [{"returncode": 0}]},
+        ),
+    ],
+)
+def test_save_prunes_raw_output_without_changing_live_messages(tmp_path, extra, saved_extra):
+    agent = ProgramBenchAgent(
+        DeterministicModel(outputs=[]),
+        LocalEnvironment(),
+        progress_manager=RunBatchProgressManager(1),
+        system_template="",
+        instance_template="",
+    )
+    agent.add_messages({"role": "tool", "content": "command output", "extra": extra})
+    messages = copy.deepcopy(agent.messages)
+
+    agent.save(tmp_path / "trajectory.json")
+
+    assert agent.messages == messages
+    assert json.loads((tmp_path / "trajectory.json").read_text())["messages"] == [
+        {"role": "tool", "content": "command output", "extra": saved_extra}
+    ]
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

`ProgramBenchAgent.serialize()` strips `raw_output` to keep trajectory files small, but the serialized `messages` list aliases `self.messages`: `recursive_merge()` copies dictionaries, not lists. Saving therefore also removes raw observation metadata from the live conversation. `DefaultAgent.run()` saves after every step.

Copy the messages before pruning. The saved format stays unchanged, and live observations remain intact. This is a state-isolation fix; rendered model-facing content is unchanged.

## Verification

- Both new regression cases fail on the unmodified source and pass with the fix. They cover direct `extra.raw_output` and nested `extra.observations`, checking both preserved live messages and pruned saved JSON.
- `python -m pytest tests/run/test_programbench.py tests/run/test_save.py tests/utils/test_serialize.py -k 'not slow' -q`: **23 passed, 1 skipped, 4 deselected**. The optional `programbench` package is absent; Docker integration tests were not run.
- All applicable repository pre-commit hooks passed, including pinned Ruff lint/format and typos.
- No model API calls or new mocks.

AI assistance: Codex helped identify the aliasing defect, implement the change, and run the regression tests and checks.
